### PR TITLE
fix: update fastxml parser to clear CVE-2026-25128

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11012,9 +11012,9 @@
       "license": "MIT"
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.2.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
-      "integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.3.4.tgz",
+      "integrity": "sha512-EFd6afGmXlCx8H8WTZHhAoDaWaGyuIBoZJ2mknrNxug+aZKjkp0a0dlars9Izl+jF+7Gu1/5f/2h68cQpe0IiA==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,8 @@
     "rollup": "npm:@rollup/wasm-node",
     "glob": "^10.5.0",
     "@remix-run/router": "^1.23.2",
-    "qs": "^6.14.1"
+    "qs": "^6.14.1",
+    "fast-xml-parser": "^5.3.4"
   },
   "engines": {
     "node": ">=20.0.0"


### PR DESCRIPTION
## What changed?

Quick hotfix for fastxml parser

## Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor/cleanup
- [ ] Other

## Related issue

Closes # --none--

## Checklist

- [x] Tested locally
- [x] No lint/type errors
- [x] Ready for review
