### PR TITLE
Fix email implementation cleanup flow

### DIFF
--- a/app/components/orders/GenerateInvoicePdfModal.tsx
+++ b/app/components/orders/GenerateInvoicePdfModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import PdfGenerationModal from "~/components/shared/PdfGenerationModal";
 import {
   InvoicePdfTemplate,
@@ -16,6 +16,7 @@ interface GenerateInvoicePdfModalProps {
   lineItems?: (OrderLineItem | QuoteLineItem)[];
   parts?: (Part | null)[];
   autoDownload?: boolean;
+  initialPresetId?: InvoicePdfPresetId;
 }
 
 export default function GenerateInvoicePdfModal({
@@ -25,9 +26,17 @@ export default function GenerateInvoicePdfModal({
   lineItems = [],
   parts = [],
   autoDownload = true,
+  initialPresetId = "default",
 }: GenerateInvoicePdfModalProps) {
-  const [presetId, setPresetId] = useState<InvoicePdfPresetId>("default");
+  const [presetId, setPresetId] = useState<InvoicePdfPresetId>(initialPresetId);
   const isOrder = "orderNumber" in entity;
+
+  useEffect(() => {
+    if (isOpen) {
+      setPresetId(initialPresetId);
+    }
+  }, [initialPresetId, isOpen]);
+
   const apiEndpoint = isOrder
     ? `/orders/${entity.orderNumber}`
     : `/quotes/${entity.id}`;

--- a/app/components/orders/SendOrderConfirmationModal.tsx
+++ b/app/components/orders/SendOrderConfirmationModal.tsx
@@ -389,6 +389,9 @@ export default function SendOrderConfirmationModal({
     requiredAttachmentDocumentKinds.every(
       (k) => (selectedPrimaryByKind[k] ?? null) != null,
     );
+  const missingRequiredAttachmentLabels = requiredAttachmentDocumentKinds
+    .filter((k) => (selectedPrimaryByKind[k] ?? null) == null)
+    .map((k) => ATTACHMENT_DOCUMENT_KIND_LABELS[k]);
 
   const canSend =
     allRequiredPrimariesSelected &&
@@ -837,6 +840,13 @@ export default function SendOrderConfirmationModal({
               </div>
             </div>
 
+            {/* Attachment validation */}
+            {missingRequiredAttachmentLabels.length > 0 && (
+              <div className="px-4 py-3 rounded-md bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-700 text-sm text-amber-800 dark:text-amber-200">
+                Add required attachments before sending: {missingRequiredAttachmentLabels.join(", ")}.
+              </div>
+            )}
+
             {/* Submit error */}
             {submitError && (
               <div className="px-4 py-3 rounded-md bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-700 text-sm text-red-700 dark:text-red-300">
@@ -856,7 +866,7 @@ export default function SendOrderConfirmationModal({
               disabled={!canSend}
               title={
                 !allRequiredPrimariesSelected
-                  ? "Add every required document type for this email template"
+                  ? `Add required attachments before sending: ${missingRequiredAttachmentLabels.join(", ")}`
                   : isOverSizeLimit
                     ? "Attachments exceed 10 MB limit"
                     : undefined

--- a/app/lib/email/send-draft-template-test-email.server.ts
+++ b/app/lib/email/send-draft-template-test-email.server.ts
@@ -25,8 +25,6 @@ import type { ActorMergeSource } from "~/lib/email/resolve/actor-merge.server";
 import { buildActorMergeMap } from "~/lib/email/resolve/actor-merge.server";
 import { getEmailMergeFieldsMap } from "~/lib/email/templates.server";
 
-const SUBJECT_PREVIEW_PREFIX = "[Template preview] ";
-
 /**
  * Default merge values for layout props and button URL rules. Extend when new
  * email layouts are registered.
@@ -181,15 +179,13 @@ export async function sendDraftTemplateTestEmail(params: {
   textBody = replaceUnresolvedPlaceholders(textBody);
   subjectResolved = replaceUnresolvedPlaceholders(subjectResolved);
 
-  const fullSubject = `${SUBJECT_PREVIEW_PREFIX}${subjectResolved}`;
-
   try {
     await sendPostmarkTransactionalEmail({
       fromEmail: identity.fromEmail,
       fromDisplayName: identity.fromDisplayName,
       toAddresses: [to],
       replyTo: identity.replyToEmail,
-      subject: fullSubject,
+      subject: subjectResolved,
       htmlBody: sanitizeEmailHtml(rawHtml),
       textBody,
     });

--- a/app/routes/_protected.orders.$orderId.tsx
+++ b/app/routes/_protected.orders.$orderId.tsx
@@ -1656,6 +1656,7 @@ export default function OrderDetails() {
   const actionsButtonRef = useRef<HTMLButtonElement>(null);
   const [isPOModalOpen, setIsPOModalOpen] = useState(false);
   const [isInvoiceModalOpen, setIsInvoiceModalOpen] = useState(false);
+  const [invoicePdfFromEmailContext, setInvoicePdfFromEmailContext] = useState(false);
   const [isPackingSlipModalOpen, setIsPackingSlipModalOpen] = useState(false);
   const [isSendOrderConfirmationModalOpen, setSendOrderConfirmationModalOpen] =
     useState(false);
@@ -2169,6 +2170,7 @@ export default function OrderDetails() {
   }, [editOrderModalOpen, handleEditOrderSubmit]);
 
   const handleGenerateInvoice = () => {
+    setInvoicePdfFromEmailContext(false);
     setIsInvoiceModalOpen(true);
   };
 
@@ -2973,11 +2975,15 @@ export default function OrderDetails() {
       {/* Invoice PDF Modal */}
       <GenerateInvoicePdfModal
         isOpen={isInvoiceModalOpen}
-        onClose={() => setIsInvoiceModalOpen(false)}
+        onClose={() => {
+          setIsInvoiceModalOpen(false);
+          setInvoicePdfFromEmailContext(false);
+        }}
         entity={order}
         lineItems={lineItems.map((item: LineItemWithPart) => item.lineItem)}
         parts={lineItems.map((item: LineItemWithPart) => item.part)}
-        autoDownload={pdfAutoDownload}
+        autoDownload={invoicePdfFromEmailContext ? false : pdfAutoDownload}
+        initialPresetId={invoicePdfFromEmailContext ? "paid" : "default"}
       />
 
       <GeneratePackingSlipPdfModal
@@ -3012,6 +3018,7 @@ export default function OrderDetails() {
           }
           onRequestGenerateForDocumentKind={(kind) => {
             if (kind === "invoice") {
+              setInvoicePdfFromEmailContext(true);
               setIsInvoiceModalOpen(true);
               return;
             }


### PR DESCRIPTION
Fixes #126.

## Summary
- Show a visible missing-required-attachments message in the order-confirmation email modal, including the specific required document labels.
- When generating an invoice from the order-confirmation attachment flow, open the invoice modal with the `Paid` preset and skip auto-download so the generated PDF can be attached from the email flow.
- Remove the `[Template preview]` prefix from draft template test-email subjects.

## Verification
- Live guard before PR: issue #126 was open, unlocked, unassigned; duplicate PR search returned no results.
- `git -c core.whitespace=cr-at-eol diff --check` passed.
- Package-manager checks not run: this runner has no `npm`, `npx`, or `bun` installed.

## Safety
No customer data, SMTP credentials, live email sending, deployment, billing, payment, wallet, or account/KYC action used.
