### PR TITLE
129 pull shipping from stripe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,6 +124,8 @@ CLAUDE.md
 .cursorrules
 .cursor
 
+.agents
+
 /planning
 /logs
 /scripts

--- a/app/components/orders/CheckoutAddressConflictModal.tsx
+++ b/app/components/orders/CheckoutAddressConflictModal.tsx
@@ -1,0 +1,466 @@
+import { useState, useEffect } from "react";
+import type { CheckoutAddressConflictPreview } from "~/lib/stripe/checkout-address-conflict.types";
+
+type Choice = "checkout" | "on_file";
+
+export type CheckoutAddressImportPhase =
+  | "working"
+  | "conflict"
+  | "submitting_choices"
+  | "success"
+  | "noop"
+  | "error";
+
+export type CheckoutAddressImportProgressStep =
+  | "connecting"
+  | "fetching"
+  | "comparing"
+  | "applying";
+
+export type CheckoutAddressConflictModalProps = {
+  open: boolean;
+  phase: CheckoutAddressImportPhase;
+  /** Active progress step while phase is "working" or "submitting_choices". */
+  progressStep?: CheckoutAddressImportProgressStep;
+  preview: CheckoutAddressConflictPreview | null;
+  /** Optional summary used in success/noop screens. */
+  summary?: {
+    billingUpdated?: boolean;
+    shippingUpdated?: boolean;
+    phoneUpdated?: boolean;
+  };
+  errorMessage?: string;
+  onClose: () => void;
+  onConfirm: (choices: {
+    billingChoice?: Choice;
+    shippingChoice?: Choice;
+    phoneChoice?: Choice;
+  }) => void;
+  onRetry?: () => void;
+};
+
+const STEP_ORDER: CheckoutAddressImportProgressStep[] = [
+  "connecting",
+  "fetching",
+  "comparing",
+  "applying",
+];
+
+const STEP_LABELS: Record<CheckoutAddressImportProgressStep, string> = {
+  connecting: "Connecting to payment checkout",
+  fetching: "Fetching customer information from quote payment",
+  comparing: "Comparing with customer record on file",
+  applying: "Updating customer record",
+};
+
+function ProgressList({
+  active,
+  isSubmittingChoices,
+}: {
+  active?: CheckoutAddressImportProgressStep;
+  isSubmittingChoices?: boolean;
+}) {
+  const activeIndex = active ? STEP_ORDER.indexOf(active) : 0;
+  return (
+    <ul className="space-y-2">
+      {STEP_ORDER.map((step, idx) => {
+        const isApplying = step === "applying";
+        const isSkipped = isApplying && !isSubmittingChoices && active !== "applying";
+        const isCurrent = idx === activeIndex;
+        const isDone = idx < activeIndex;
+        return (
+          <li
+            key={step}
+            className="flex items-center gap-3 text-sm"
+            aria-current={isCurrent ? "step" : undefined}
+          >
+            <span
+              className={`relative flex h-5 w-5 shrink-0 items-center justify-center rounded-full border ${
+                isDone
+                  ? "border-green-500 bg-green-500"
+                  : isCurrent
+                    ? "border-blue-500"
+                    : "border-gray-300 dark:border-gray-600"
+              }`}
+            >
+              {isDone ? (
+                <svg
+                  viewBox="0 0 20 20"
+                  className="h-3 w-3 text-white"
+                  fill="currentColor"
+                >
+                  <path
+                    fillRule="evenodd"
+                    d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+                    clipRule="evenodd"
+                  />
+                </svg>
+              ) : isCurrent ? (
+                <span className="h-2 w-2 animate-pulse rounded-full bg-blue-500" />
+              ) : null}
+            </span>
+            <span
+              className={`${
+                isDone
+                  ? "text-gray-700 dark:text-gray-200"
+                  : isCurrent
+                    ? "text-gray-900 dark:text-gray-100 font-medium"
+                    : isSkipped
+                      ? "text-gray-400 dark:text-gray-500 line-through"
+                      : "text-gray-500 dark:text-gray-400"
+              }`}
+            >
+              {STEP_LABELS[step]}
+            </span>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+function StatusIcon({ kind }: { kind: "success" | "noop" | "error" }) {
+  if (kind === "success") {
+    return (
+      <svg
+        className="h-6 w-6 text-green-500"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M5 13l4 4L19 7"
+        />
+      </svg>
+    );
+  }
+  if (kind === "noop") {
+    return (
+      <svg
+        className="h-6 w-6 text-gray-500"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M13 16h-1v-4h-1m1-4h.01M12 22a10 10 0 110-20 10 10 0 010 20z"
+        />
+      </svg>
+    );
+  }
+  return (
+    <svg
+      className="h-6 w-6 text-red-500"
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M12 9v2m0 4h.01M5.07 19h13.86c1.54 0 2.5-1.67 1.73-3L13.73 4a2 2 0 00-3.46 0L3.34 16c-.77 1.33.19 3 1.73 3z"
+      />
+    </svg>
+  );
+}
+
+export default function CheckoutAddressConflictModal({
+  open,
+  phase,
+  progressStep,
+  preview,
+  summary,
+  errorMessage,
+  onClose,
+  onConfirm,
+  onRetry,
+}: CheckoutAddressConflictModalProps) {
+  const [billing, setBilling] = useState<Choice | null>(null);
+  const [shipping, setShipping] = useState<Choice | null>(null);
+  const [phone, setPhone] = useState<Choice | null>(null);
+
+  useEffect(() => {
+    if (open && preview) {
+      setBilling(null);
+      setShipping(null);
+      setPhone(null);
+    }
+  }, [open, preview?.quoteId]);
+
+  if (!open) return null;
+
+  const needBilling = preview?.chooseBilling ?? false;
+  const needShipping = preview?.chooseShipping ?? false;
+  const needPhone = preview?.choosePhone ?? false;
+
+  const submittingChoices = phase === "submitting_choices";
+
+  const canSubmit =
+    !!preview &&
+    (!needBilling || billing !== null) &&
+    (!needShipping || shipping !== null) &&
+    (!needPhone || phone !== null) &&
+    !submittingChoices;
+
+  const handleConfirm = () => {
+    if (!canSubmit) return;
+    onConfirm({
+      ...(needBilling ? { billingChoice: billing! } : {}),
+      ...(needShipping ? { shippingChoice: shipping! } : {}),
+      ...(needPhone ? { phoneChoice: phone! } : {}),
+    });
+  };
+
+  const ChoiceRow = ({
+    label,
+    checkoutLabel,
+    onFileLabel,
+    value,
+    onChange,
+    show,
+    radioName,
+  }: {
+    label: string;
+    checkoutLabel: string;
+    onFileLabel: string;
+    value: Choice | null;
+    onChange: (c: Choice) => void;
+    show: boolean;
+    radioName: string;
+  }) => {
+    if (!show) return null;
+    return (
+      <div className="border border-gray-200 dark:border-gray-600 rounded-lg p-4 space-y-3">
+        <p className="text-sm font-medium text-gray-900 dark:text-gray-100">
+          {label}
+        </p>
+        <div className="grid gap-2 sm:grid-cols-2 text-sm">
+          <label className="flex cursor-pointer gap-2 rounded-md border border-gray-200 dark:border-gray-600 p-3 has-[:checked]:border-blue-500 has-[:checked]:bg-blue-50/50 dark:has-[:checked]:bg-blue-950/30">
+            <input
+              type="radio"
+              name={radioName}
+              checked={value === "checkout"}
+              onChange={() => onChange("checkout")}
+              className="mt-0.5"
+              disabled={submittingChoices}
+            />
+            <span className="text-gray-800 dark:text-gray-200 whitespace-pre-wrap">
+              {checkoutLabel}
+            </span>
+          </label>
+          <label className="flex cursor-pointer gap-2 rounded-md border border-gray-200 dark:border-gray-600 p-3 has-[:checked]:border-blue-500 has-[:checked]:bg-blue-50/50 dark:has-[:checked]:bg-blue-950/30">
+            <input
+              type="radio"
+              name={radioName}
+              checked={value === "on_file"}
+              onChange={() => onChange("on_file")}
+              className="mt-0.5"
+              disabled={submittingChoices}
+            />
+            <span className="text-gray-800 dark:text-gray-200 whitespace-pre-wrap">
+              {onFileLabel}
+            </span>
+          </label>
+        </div>
+      </div>
+    );
+  };
+
+  return (
+    <div className="fixed inset-0 z-[100] flex items-center justify-center p-4 bg-black/50">
+      <div className="bg-white dark:bg-gray-800 rounded-lg shadow-xl max-w-2xl w-full max-h-[90vh] overflow-y-auto p-6 space-y-4">
+        <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
+          Import addresses from quote payment
+        </h2>
+
+        {phase === "working" && (
+          <>
+            <p className="text-sm text-gray-600 dark:text-gray-400">
+              Looking up the latest payment checkout for this order&rsquo;s
+              quote and comparing the captured information with your customer
+              record.
+            </p>
+            <ProgressList active={progressStep} />
+            <div className="flex justify-end pt-2">
+              <button
+                type="button"
+                onClick={onClose}
+                className="px-4 py-2 text-sm rounded-md border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700"
+              >
+                Close
+              </button>
+            </div>
+          </>
+        )}
+
+        {phase === "conflict" && preview && (
+          <>
+            <p className="text-sm text-gray-600 dark:text-gray-400">
+              We compared what the customer entered at payment checkout to what
+              you have on file. Pick which version to keep for each section
+              below. Nothing is saved until you confirm.
+            </p>
+
+            <ChoiceRow
+              label="Billing address"
+              checkoutLabel={`From checkout:\n${preview.stripeBillingText || "—"}`}
+              onFileLabel={`On file:\n${preview.onFileBillingText || "—"}`}
+              value={billing}
+              onChange={setBilling}
+              show={needBilling}
+              radioName="billing-import-src"
+            />
+
+            <ChoiceRow
+              label="Shipping address"
+              checkoutLabel={`From checkout:\n${preview.stripeShippingText || "—"}`}
+              onFileLabel={`On file:\n${preview.onFileShippingText || "—"}`}
+              value={shipping}
+              onChange={setShipping}
+              show={needShipping}
+              radioName="shipping-import-src"
+            />
+
+            <ChoiceRow
+              label="Phone"
+              checkoutLabel={`From checkout:\n${preview.stripePhone || "—"}`}
+              onFileLabel={`On file:\n${preview.onFilePhone || "—"}`}
+              value={phone}
+              onChange={setPhone}
+              show={needPhone}
+              radioName="phone-import-src"
+            />
+
+            <div className="flex justify-end gap-2 pt-2">
+              <button
+                type="button"
+                onClick={onClose}
+                disabled={submittingChoices}
+                className="px-4 py-2 text-sm rounded-md border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                disabled={!canSubmit}
+                onClick={handleConfirm}
+                className="px-4 py-2 text-sm rounded-md bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {submittingChoices ? "Saving…" : "Confirm"}
+              </button>
+            </div>
+          </>
+        )}
+
+        {phase === "submitting_choices" && preview && (
+          <>
+            <p className="text-sm text-gray-600 dark:text-gray-400">
+              Saving your selections to the customer record…
+            </p>
+            <ProgressList active="applying" isSubmittingChoices />
+          </>
+        )}
+
+        {phase === "success" && (
+          <>
+            <div className="flex items-start gap-3">
+              <StatusIcon kind="success" />
+              <div className="space-y-1">
+                <p className="text-sm font-medium text-gray-900 dark:text-gray-100">
+                  Customer record updated
+                </p>
+                <p className="text-sm text-gray-600 dark:text-gray-400">
+                  Imported {[
+                    summary?.billingUpdated ? "billing address" : null,
+                    summary?.shippingUpdated ? "shipping address" : null,
+                    summary?.phoneUpdated ? "phone" : null,
+                  ]
+                    .filter(Boolean)
+                    .join(", ") || "address information"}{" "}
+                  from the latest payment checkout.
+                </p>
+              </div>
+            </div>
+            <div className="flex justify-end pt-2">
+              <button
+                type="button"
+                onClick={onClose}
+                className="px-4 py-2 text-sm rounded-md bg-blue-600 text-white hover:bg-blue-700"
+              >
+                Done
+              </button>
+            </div>
+          </>
+        )}
+
+        {phase === "noop" && (
+          <>
+            <div className="flex items-start gap-3">
+              <StatusIcon kind="noop" />
+              <div className="space-y-1">
+                <p className="text-sm font-medium text-gray-900 dark:text-gray-100">
+                  Nothing to update
+                </p>
+                <p className="text-sm text-gray-600 dark:text-gray-400">
+                  {errorMessage ??
+                    "The customer record already matches the latest payment checkout."}
+                </p>
+              </div>
+            </div>
+            <div className="flex justify-end pt-2">
+              <button
+                type="button"
+                onClick={onClose}
+                className="px-4 py-2 text-sm rounded-md bg-blue-600 text-white hover:bg-blue-700"
+              >
+                Close
+              </button>
+            </div>
+          </>
+        )}
+
+        {phase === "error" && (
+          <>
+            <div className="flex items-start gap-3">
+              <StatusIcon kind="error" />
+              <div className="space-y-1">
+                <p className="text-sm font-medium text-gray-900 dark:text-gray-100">
+                  Couldn&rsquo;t import addresses
+                </p>
+                <p className="text-sm text-gray-600 dark:text-gray-400">
+                  {errorMessage ??
+                    "Something went wrong reading from the payment checkout."}
+                </p>
+              </div>
+            </div>
+            <div className="flex justify-end gap-2 pt-2">
+              <button
+                type="button"
+                onClick={onClose}
+                className="px-4 py-2 text-sm rounded-md border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700"
+              >
+                Close
+              </button>
+              {onRetry && (
+                <button
+                  type="button"
+                  onClick={onRetry}
+                  className="px-4 py-2 text-sm rounded-md bg-blue-600 text-white hover:bg-blue-700"
+                >
+                  Try again
+                </button>
+              )}
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/components/orders/GenerateInvoicePdfModal.tsx
+++ b/app/components/orders/GenerateInvoicePdfModal.tsx
@@ -1,4 +1,4 @@
-import { useLayoutEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import PdfGenerationModal from "~/components/shared/PdfGenerationModal";
 import {
   InvoicePdfTemplate,
@@ -32,7 +32,7 @@ export default function GenerateInvoicePdfModal({
   const [presetId, setPresetId] = useState<InvoicePdfPresetId>(initialPresetId);
   const isOrder = "orderNumber" in entity;
 
-  useLayoutEffect(() => {
+  useEffect(() => {
     if (isOpen) {
       setPresetId(initialPresetId);
     }

--- a/app/components/orders/InvoicePdfTemplate.tsx
+++ b/app/components/orders/InvoicePdfTemplate.tsx
@@ -8,7 +8,11 @@ import {
   commonPdfStyles,
   type PdfPresetOption,
 } from "~/lib/pdf-utils";
-import { extractShippingAddress, isAddressComplete } from "~/lib/address-utils";
+import {
+  extractBillingAddress,
+  extractShippingAddress,
+  isAddressComplete,
+} from "~/lib/address-utils";
 
 export const INVOICE_PDF_PRESETS = [
   { id: "default", label: "Default" },
@@ -638,7 +642,7 @@ export function InvoicePdfTemplate({
               {/* Billing Address */}
               {entity.customer &&
                 (() => {
-                  const billingAddress = extractShippingAddress(
+                  const billingAddress = extractBillingAddress(
                     entity.customer
                   );
                   const hasBillingAddress = isAddressComplete(billingAddress);

--- a/app/components/orders/OrderActionsDropdown.tsx
+++ b/app/components/orders/OrderActionsDropdown.tsx
@@ -15,6 +15,11 @@ interface OrderActionsDropdownProps {
   hasCustomer?: boolean;
   showOrderConfirmationInMenu?: boolean;
   orderConfirmationMenuDisabled?: boolean;
+  /** Import billing/shipping from quote payment checkout (when flag on + quote has payment link) */
+  onImportCheckoutAddresses?: () => void;
+  showImportCheckoutAddresses?: boolean;
+  importCheckoutAddressesDisabled?: boolean;
+  importCheckoutAddressesTooltip?: string;
 }
 
 export default function OrderActionsDropdown({
@@ -31,6 +36,10 @@ export default function OrderActionsDropdown({
   hasCustomer = false,
   showOrderConfirmationInMenu = false,
   orderConfirmationMenuDisabled = false,
+  onImportCheckoutAddresses,
+  showImportCheckoutAddresses = false,
+  importCheckoutAddressesDisabled = false,
+  importCheckoutAddressesTooltip = "",
 }: OrderActionsDropdownProps) {
   const dropdownRef = useRef<HTMLDivElement>(null);
 
@@ -192,6 +201,40 @@ export default function OrderActionsDropdown({
           },
         ]
       : []),
+    ...(onImportCheckoutAddresses && showImportCheckoutAddresses
+      ? [
+          {
+            icon: (
+              <svg
+                className="w-5 h-5"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"
+                />
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"
+                />
+              </svg>
+            ),
+            label: "Addresses",
+            onClick: () => {
+              onImportCheckoutAddresses();
+              onClose();
+            },
+            disabled: importCheckoutAddressesDisabled,
+            disabledTooltip: importCheckoutAddressesTooltip || undefined,
+          },
+        ]
+      : []),
     ...(onDuplicate
       ? [
           {
@@ -233,16 +276,15 @@ export default function OrderActionsDropdown({
           const isInvoiceButton = action.label === "Invoice";
           const isPackingSlipButton = action.label === "Packing slip";
           const isConfirmationButton = action.label === "Confirmation";
-          const showTooltip =
-            isDisabled &&
-            (isPOButton ||
-              isInvoiceButton ||
-              isPackingSlipButton ||
-              isConfirmationButton);
-
+          const customTooltip =
+            "disabledTooltip" in action && action.disabledTooltip
+              ? action.disabledTooltip
+              : "";
           let tooltipText = "";
-          if (showTooltip) {
-            if (isPOButton) {
+          if (isDisabled) {
+            if (customTooltip) {
+              tooltipText = customTooltip;
+            } else if (isPOButton) {
               tooltipText = "Purchase Orders require a vendor";
             } else if (isInvoiceButton) {
               tooltipText = "Invoices require a customer";
@@ -253,6 +295,7 @@ export default function OrderActionsDropdown({
                 "Customer confirmation is unavailable: missing customer email, email template, or a send already completed.";
             }
           }
+          const showTooltip = isDisabled && tooltipText.length > 0;
 
           return (
             <div key={index} className="relative group/tooltip">
@@ -278,7 +321,7 @@ export default function OrderActionsDropdown({
                 </span>
               </button>
               {showTooltip && (
-                <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 px-3 py-2 bg-gray-900 dark:bg-gray-700 text-white text-xs rounded-lg whitespace-nowrap opacity-0 invisible group-hover/tooltip:opacity-100 group-hover/tooltip:visible transition-opacity duration-200 pointer-events-none z-[60]">
+                <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 px-3 py-2 bg-gray-900 dark:bg-gray-700 text-white text-xs rounded-lg max-w-xs whitespace-normal text-left opacity-0 invisible group-hover/tooltip:opacity-100 group-hover/tooltip:visible transition-opacity duration-200 pointer-events-none z-[60]">
                   {tooltipText}
                   <div className="absolute top-full left-1/2 -translate-x-1/2 -mt-1 border-4 border-transparent border-t-gray-900 dark:border-t-gray-700"></div>
                 </div>

--- a/app/components/orders/PurchaseOrderPdfTemplate.tsx
+++ b/app/components/orders/PurchaseOrderPdfTemplate.tsx
@@ -7,7 +7,11 @@ import {
   commonPdfStyles,
   type PdfPresetOption,
 } from "~/lib/pdf-utils";
-import { extractShippingAddress, isAddressComplete } from "~/lib/address-utils";
+import {
+  extractBillingAddress,
+  extractShippingAddress,
+  isAddressComplete,
+} from "~/lib/address-utils";
 
 export const PURCHASE_ORDER_PDF_PRESETS = [
   { id: "default", label: "Default" },
@@ -523,33 +527,39 @@ export function PurchaseOrderPdfTemplate({
                   </span>
                 </p>
               )}
-              {/* Shipping Address */}
+              {/* Vendor location (structured shipping preferred; else billing) */}
               {order.vendor && (() => {
                 const shippingAddress = extractShippingAddress(order.vendor);
-                const hasShippingAddress = isAddressComplete(shippingAddress);
+                const billingAddress = extractBillingAddress(order.vendor);
+                const vendorAddress = isAddressComplete(shippingAddress)
+                  ? shippingAddress
+                  : isAddressComplete(billingAddress)
+                    ? billingAddress
+                    : shippingAddress;
+                const hasVendorAddress = isAddressComplete(vendorAddress);
 
-                if (hasShippingAddress) {
+                if (hasVendorAddress) {
                   return (
                     <>
-                      {shippingAddress.line1 && (
+                      {vendorAddress.line1 && (
                         <p>
                           <span
                             className={editable ? "editable" : ""}
                             contentEditable={editable}
                             suppressContentEditableWarning
                           >
-                            {shippingAddress.line1}
+                            {vendorAddress.line1}
                           </span>
                         </p>
                       )}
-                      {shippingAddress.line2 && (
+                      {vendorAddress.line2 && (
                         <p>
                           <span
                             className={editable ? "editable" : ""}
                             contentEditable={editable}
                             suppressContentEditableWarning
                           >
-                            {shippingAddress.line2}
+                            {vendorAddress.line2}
                           </span>
                         </p>
                       )}
@@ -559,20 +569,22 @@ export function PurchaseOrderPdfTemplate({
                           contentEditable={editable}
                           suppressContentEditableWarning
                         >
-                          {shippingAddress.city}, {shippingAddress.state} {shippingAddress.postalCode}
+                          {vendorAddress.city}, {vendorAddress.state}{" "}
+                          {vendorAddress.postalCode}
                         </span>
                       </p>
-                      {shippingAddress.country && shippingAddress.country !== "US" && (
-                        <p>
-                          <span
-                            className={editable ? "editable" : ""}
-                            contentEditable={editable}
-                            suppressContentEditableWarning
-                          >
-                            {shippingAddress.country}
-                          </span>
-                        </p>
-                      )}
+                      {vendorAddress.country &&
+                        vendorAddress.country !== "US" && (
+                          <p>
+                            <span
+                              className={editable ? "editable" : ""}
+                              contentEditable={editable}
+                              suppressContentEditableWarning
+                            >
+                              {vendorAddress.country}
+                            </span>
+                          </p>
+                        )}
                     </>
                   );
                 } else if (order.vendor?.address) {

--- a/app/components/quotes/QuotePdfTemplate.tsx
+++ b/app/components/quotes/QuotePdfTemplate.tsx
@@ -6,6 +6,11 @@ import {
   commonPdfStyles,
   type PdfPresetOption,
 } from "~/lib/pdf-utils";
+import {
+  extractBillingAddress,
+  extractShippingAddress,
+  isAddressComplete,
+} from "~/lib/address-utils";
 
 export const QUOTE_PDF_PRESETS = [
   { id: "default", label: "Default" },
@@ -578,30 +583,95 @@ export function QuotePdfTemplate({
                   {quote.customer?.email || ""}
                 </span>
               </p>
-              {editable && (
-                <>
-                  <p>
-                    <span
-                      className="editable placeholder-text address-placeholder"
-                      contentEditable={editable}
-                      suppressContentEditableWarning
-                      data-default-text="Address Line 1"
-                    >
-                      Address Line 1
-                    </span>
-                  </p>
-                  <p>
-                    <span
-                      className="editable placeholder-text address-placeholder"
-                      contentEditable={editable}
-                      suppressContentEditableWarning
-                      data-default-text="City, State ZIP"
-                    >
-                      City, State ZIP
-                    </span>
-                  </p>
-                </>
-              )}
+              {(quote.customer || editable) &&
+                (() => {
+                  const billingAddress = quote.customer
+                    ? extractBillingAddress(quote.customer)
+                    : null;
+                  const hasBillingAddress =
+                    billingAddress != null &&
+                    isAddressComplete(billingAddress);
+
+                  if (hasBillingAddress && billingAddress) {
+                    return (
+                      <>
+                        {billingAddress.line1 && (
+                          <p>
+                            <span
+                              className={editable ? "editable" : ""}
+                              contentEditable={editable}
+                              suppressContentEditableWarning
+                            >
+                              {billingAddress.line1}
+                            </span>
+                          </p>
+                        )}
+                        {billingAddress.line2 && (
+                          <p>
+                            <span
+                              className={editable ? "editable" : ""}
+                              contentEditable={editable}
+                              suppressContentEditableWarning
+                            >
+                              {billingAddress.line2}
+                            </span>
+                          </p>
+                        )}
+                        <p>
+                          <span
+                            className={editable ? "editable" : ""}
+                            contentEditable={editable}
+                            suppressContentEditableWarning
+                          >
+                            {billingAddress.city}, {billingAddress.state}{" "}
+                            {billingAddress.postalCode}
+                          </span>
+                        </p>
+                        {billingAddress.country &&
+                          billingAddress.country !== "US" && (
+                            <p>
+                              <span
+                                className={editable ? "editable" : ""}
+                                contentEditable={editable}
+                                suppressContentEditableWarning
+                              >
+                                {billingAddress.country}
+                              </span>
+                            </p>
+                          )}
+                      </>
+                    );
+                  }
+
+                  if (editable) {
+                    return (
+                      <>
+                        <p>
+                          <span
+                            className="editable placeholder-text address-placeholder"
+                            contentEditable={editable}
+                            suppressContentEditableWarning
+                            data-default-text="Address Line 1"
+                          >
+                            Address Line 1
+                          </span>
+                        </p>
+                        <p>
+                          <span
+                            className="editable placeholder-text address-placeholder"
+                            contentEditable={editable}
+                            suppressContentEditableWarning
+                            data-default-text="City, State ZIP"
+                          >
+                            City, State ZIP
+                          </span>
+                        </p>
+                      </>
+                    );
+                  }
+
+                  return null;
+                })()}
             </div>
             <div className="detail-section">
               <h3>Shipping Information</h3>
@@ -635,6 +705,96 @@ export function QuotePdfTemplate({
                   Payment in Advance
                 </span>
               </p>
+              {quote.customer &&
+                (() => {
+                  const shippingAddress = extractShippingAddress(
+                    quote.customer,
+                  );
+                  const hasShippingAddress =
+                    isAddressComplete(shippingAddress);
+
+                  if (hasShippingAddress) {
+                    return (
+                      <>
+                        <p className="primary">Ship To</p>
+                        {shippingAddress.line1 && (
+                          <p>
+                            <span
+                              className={editable ? "editable" : ""}
+                              contentEditable={editable}
+                              suppressContentEditableWarning
+                            >
+                              {shippingAddress.line1}
+                            </span>
+                          </p>
+                        )}
+                        {shippingAddress.line2 && (
+                          <p>
+                            <span
+                              className={editable ? "editable" : ""}
+                              contentEditable={editable}
+                              suppressContentEditableWarning
+                            >
+                              {shippingAddress.line2}
+                            </span>
+                          </p>
+                        )}
+                        <p>
+                          <span
+                            className={editable ? "editable" : ""}
+                            contentEditable={editable}
+                            suppressContentEditableWarning
+                          >
+                            {shippingAddress.city}, {shippingAddress.state}{" "}
+                            {shippingAddress.postalCode}
+                          </span>
+                        </p>
+                        {shippingAddress.country &&
+                          shippingAddress.country !== "US" && (
+                            <p>
+                              <span
+                                className={editable ? "editable" : ""}
+                                contentEditable={editable}
+                                suppressContentEditableWarning
+                              >
+                                {shippingAddress.country}
+                              </span>
+                            </p>
+                          )}
+                      </>
+                    );
+                  }
+
+                  if (editable) {
+                    return (
+                      <>
+                        <p className="primary">Ship To</p>
+                        <p>
+                          <span
+                            className="editable placeholder-text address-placeholder"
+                            contentEditable={editable}
+                            suppressContentEditableWarning
+                            data-default-text="Shipping Address Line 1"
+                          >
+                            Shipping Address Line 1
+                          </span>
+                        </p>
+                        <p>
+                          <span
+                            className="editable placeholder-text address-placeholder"
+                            contentEditable={editable}
+                            suppressContentEditableWarning
+                            data-default-text="Shipping City, State ZIP"
+                          >
+                            Shipping City, State ZIP
+                          </span>
+                        </p>
+                      </>
+                    );
+                  }
+
+                  return null;
+                })()}
             </div>
           </div>
 

--- a/app/components/shared/LineItemRow.tsx
+++ b/app/components/shared/LineItemRow.tsx
@@ -1,4 +1,4 @@
-import { useLayoutEffect, useRef, type ReactNode } from "react";
+import { useEffect, useRef, type ReactNode } from "react";
 import { Box } from "lucide-react";
 import { PartAssetAdminTrigger } from "~/components/admin/PartAssetAdminFlyout";
 import { IconButton } from "~/components/shared/IconButton";
@@ -162,7 +162,7 @@ export function LineItemRow({
   const isEditing = (field: LineItemEditableField) =>
     editingField?.lineItemId === item.id && editingField.field === field;
 
-  useLayoutEffect(() => {
+  useEffect(() => {
     if (
       editingField?.lineItemId === item.id &&
       editingField.field === "name"

--- a/app/components/shared/PdfGenerationModal.tsx
+++ b/app/components/shared/PdfGenerationModal.tsx
@@ -100,6 +100,8 @@ export default function PdfGenerationModal({
         const defaultPlaceholders = [
           'Address Line 1',
           'City, State ZIP',
+          'Shipping Address Line 1',
+          'Shipping City, State ZIP',
           'Phone Number',
           'Mailing Address',
           'Email',

--- a/app/lib/address-utils.ts
+++ b/app/lib/address-utils.ts
@@ -90,6 +90,20 @@ export function isAddressEmpty(address: Address): boolean {
 }
 
 /**
+ * True when there is no street/city/state/ZIP data — only a default country (e.g. schema default "US")
+ * does not count as an existing address for merge/import flows.
+ */
+export function isAddressMeaningfullyEmpty(address: Address): boolean {
+  return !(
+    address.line1?.trim() ||
+    address.line2?.trim() ||
+    address.city?.trim() ||
+    address.state?.trim() ||
+    address.postalCode?.trim()
+  );
+}
+
+/**
  * Convert address object to format expected by shipping APIs
  * (e.g., UPS, FedEx, USPS, ShipStation)
  */

--- a/app/lib/customers.ts
+++ b/app/lib/customers.ts
@@ -33,6 +33,12 @@ export type CustomerInput = {
 export type CustomerEventContext = {
   userId?: string
   userEmail?: string
+  /** When set, logs a dedicated checkout-import event instead of generic customer_updated */
+  checkoutAddressImport?: {
+    quoteId: number
+    orderId?: number
+    quoteNumber?: string
+  }
 }
 
 export async function getCustomers(): Promise<Customer[]> {
@@ -119,18 +125,35 @@ export async function updateCustomer(id: number, customerData: Partial<CustomerI
 
     const customer = result[0]
 
-    // Log event for customer update
-    await createEvent({
-      entityType: "customer",
-      entityId: id.toString(),
-      eventType: "customer_updated",
-      eventCategory: "system",
-      title: `Customer information updated`,
-      description: `Customer "${customer.displayName}" details were updated`,
-      metadata: customerData,
-      userId: eventContext?.userId,
-      userEmail: eventContext?.userEmail,
-    })
+    if (eventContext?.checkoutAddressImport) {
+      await createEvent({
+        entityType: "customer",
+        entityId: id.toString(),
+        eventType: "customer_checkout_addresses_imported",
+        eventCategory: "system",
+        title: "Addresses imported from checkout",
+        description: `Billing/shipping or phone were imported from the quote payment checkout.`,
+        metadata: {
+          ...eventContext.checkoutAddressImport,
+          updatedFields: Object.keys(customerData),
+        },
+        userId: eventContext?.userId,
+        userEmail: eventContext?.userEmail,
+      })
+    } else {
+      // Log event for customer update
+      await createEvent({
+        entityType: "customer",
+        entityId: id.toString(),
+        eventType: "customer_updated",
+        eventCategory: "system",
+        title: `Customer information updated`,
+        description: `Customer "${customer.displayName}" details were updated`,
+        metadata: customerData,
+        userId: eventContext?.userId,
+        userEmail: eventContext?.userEmail,
+      })
+    }
 
     return customer
   } catch (error) {

--- a/app/lib/orders.ts
+++ b/app/lib/orders.ts
@@ -21,6 +21,7 @@ export type OrderWithRelations = {
   customerId: number | null
   vendorId: number | null
   quoteId: number | null
+  sourceQuoteId: number | null
   status: 'Pending' | 'Waiting_For_Shop_Selection' | 'In_Production' | 'In_Inspection' | 'Shipped' | 'Delivered' | 'Completed' | 'Cancelled' | 'Archived'
   totalPrice: string | null
   vendorPay: string | null
@@ -59,6 +60,7 @@ export async function getOrdersWithRelations(): Promise<OrderWithRelations[]> {
         customerId: orders.customerId,
         vendorId: orders.vendorId,
         quoteId: orders.quoteId,
+        sourceQuoteId: orders.sourceQuoteId,
         status: orders.status,
         totalPrice: orders.totalPrice,
         vendorPay: orders.vendorPay,
@@ -107,6 +109,7 @@ export async function getOrder(id: number): Promise<OrderWithRelations | null> {
         customerId: orders.customerId,
         vendorId: orders.vendorId,
         quoteId: orders.quoteId,
+        sourceQuoteId: orders.sourceQuoteId,
         status: orders.status,
         totalPrice: orders.totalPrice,
         vendorPay: orders.vendorPay,
@@ -139,6 +142,7 @@ export async function getOrderByNumber(orderNumber: string): Promise<OrderWithRe
         customerId: orders.customerId,
         vendorId: orders.vendorId,
         quoteId: orders.quoteId,
+        sourceQuoteId: orders.sourceQuoteId,
         status: orders.status,
         totalPrice: orders.totalPrice,
         vendorPay: orders.vendorPay,
@@ -229,6 +233,7 @@ export async function createOrder(orderData: OrderInput, eventContext?: OrderEve
         customerId: orders.customerId,
         vendorId: orders.vendorId,
         quoteId: orders.quoteId,
+        sourceQuoteId: orders.sourceQuoteId,
         status: orders.status,
         totalPrice: orders.totalPrice,
         vendorPay: orders.vendorPay,
@@ -391,6 +396,7 @@ export async function updateOrder(id: number, orderData: Partial<OrderInput>, ev
         customerId: orders.customerId,
         vendorId: orders.vendorId,
         quoteId: orders.quoteId,
+        sourceQuoteId: orders.sourceQuoteId,
         status: orders.status,
         totalPrice: orders.totalPrice,
         vendorPay: orders.vendorPay,

--- a/app/lib/quotes.ts
+++ b/app/lib/quotes.ts
@@ -1087,6 +1087,19 @@ export async function convertQuoteToOrder(
       userEmail: context?.userEmail,
     });
 
+    const { tryAutoFillBlankCustomerFromQuoteCheckout } = await import(
+      "~/lib/stripe/checkout-addresses.server"
+    );
+    await tryAutoFillBlankCustomerFromQuoteCheckout({
+      quoteId,
+      customerId: quote.customerId,
+      orderId: result.orderId,
+      eventContext: {
+        userId: context?.userId,
+        userEmail: context?.userEmail,
+      },
+    });
+
     return {
       success: true,
       orderId: result.orderId,

--- a/app/lib/stripe/checkout-address-conflict.types.ts
+++ b/app/lib/stripe/checkout-address-conflict.types.ts
@@ -1,0 +1,16 @@
+/**
+ * Client-safe payload for checkout address conflict UI (no Stripe / DB imports).
+ */
+export type CheckoutAddressConflictPreview = {
+  quoteId: number;
+  quoteNumber: string;
+  chooseBilling: boolean;
+  chooseShipping: boolean;
+  choosePhone: boolean;
+  stripeBillingText: string;
+  stripeShippingText: string;
+  onFileBillingText: string;
+  onFileShippingText: string;
+  stripePhone: string | null;
+  onFilePhone: string | null;
+};

--- a/app/lib/stripe/checkout-addresses.server.test.ts
+++ b/app/lib/stripe/checkout-addresses.server.test.ts
@@ -1,0 +1,257 @@
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("~/lib/db", () => ({
+  db: {
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          limit: vi.fn(() => Promise.resolve([])),
+        })),
+      })),
+    })),
+  },
+}));
+
+vi.mock("~/lib/customers", () => ({
+  getCustomer: vi.fn(),
+  updateCustomer: vi.fn(),
+}));
+
+vi.mock("~/lib/stripe.server", () => ({
+  getStripeClient: vi.fn(() => null),
+}));
+
+vi.mock("~/lib/featureFlags", () => ({
+  isStripePaymentLinksEnabled: vi.fn(() => Promise.resolve(false)),
+}));
+
+import {
+  mapStripeSessionToSnapshot,
+  addressesEqual,
+  phonesEqual,
+  customerAddressesFullyBlank,
+  snapshotToPartialCustomerInput,
+  type CheckoutSessionAddressSource,
+} from "./checkout-addresses.server";
+import type { Customer } from "~/lib/db/schema";
+import { isAddressMeaningfullyEmpty } from "~/lib/address-utils";
+
+describe("checkout-addresses.server", () => {
+  it("isAddressMeaningfullyEmpty ignores country-only rows", () => {
+    expect(
+      isAddressMeaningfullyEmpty({
+        line1: null,
+        city: null,
+        state: null,
+        postalCode: null,
+        country: "US",
+      })
+    ).toBe(true);
+  });
+
+  it("mapStripeSessionToSnapshot reads shipping from collected_information (Stripe API)", () => {
+    const snap = mapStripeSessionToSnapshot({
+      customer_details: {
+        email: "j@example.com",
+        phone: "(530) 383-9339",
+        address: {
+          line1: "875 West Southwood Drive",
+          line2: null,
+          city: "Woodland",
+          state: "CA",
+          postal_code: "95695",
+          country: "US",
+        },
+      },
+      collected_information: {
+        business_name: null,
+        individual_name: null,
+        shipping_details: {
+          name: "Jacob Munoz",
+          address: {
+            line1: "5595 Shannon Ave SE",
+            line2: null,
+            city: "Salem",
+            state: "OR",
+            postal_code: "97306",
+            country: "US",
+          },
+        },
+      },
+    } as CheckoutSessionAddressSource);
+
+    expect(snap.billing?.city).toBe("Woodland");
+    expect(snap.shipping?.city).toBe("Salem");
+    expect(snap.shipping?.line1).toBe("5595 Shannon Ave SE");
+    expect(snap.billing?.line1).toBe("875 West Southwood Drive");
+  });
+
+  it("mapStripeSessionToSnapshot prefers collected_information over legacy shipping_details when both set", () => {
+    const snap = mapStripeSessionToSnapshot({
+      customer_details: {
+        address: {
+          line1: "1 Bill St",
+          city: "Austin",
+          state: "TX",
+          postal_code: "78701",
+          country: "US",
+        },
+      },
+      shipping_details: {
+        address: {
+          line1: "9 Legacy Ship",
+          city: "Dallas",
+          state: "TX",
+          postal_code: "75201",
+          country: "US",
+        },
+      },
+      collected_information: {
+        business_name: null,
+        individual_name: null,
+        shipping_details: {
+          name: "X",
+          address: {
+            line1: "2 Collected Ship",
+            city: "Salem",
+            state: "OR",
+            postal_code: "97306",
+            country: "US",
+          },
+        },
+      },
+    } as CheckoutSessionAddressSource);
+
+    expect(snap.shipping?.line1).toBe("2 Collected Ship");
+  });
+
+  it("mapStripeSessionToSnapshot prefers shipping_details when present", () => {
+    const snap = mapStripeSessionToSnapshot({
+      customer_details: {
+        email: "a@b.com",
+        phone: "+1 555-0100",
+        address: {
+          line1: "1 Main",
+          line2: "Suite 2",
+          city: "Austin",
+          state: "TX",
+          postal_code: "78701",
+          country: "US",
+        },
+      },
+      shipping_details: {
+        address: {
+          line1: "9 Ship",
+          line2: null,
+          city: "Dallas",
+          state: "TX",
+          postal_code: "75201",
+          country: "US",
+        },
+      },
+    } as CheckoutSessionAddressSource);
+
+    expect(snap.phone).toBe("+1 555-0100");
+    expect(snap.billing?.line1).toBe("1 Main");
+    expect(snap.shipping?.line1).toBe("9 Ship");
+  });
+
+  it("mapStripeSessionToSnapshot clones billing into shipping when only billing present", () => {
+    const snap = mapStripeSessionToSnapshot({
+      customer_details: {
+        phone: "+1 555-0100",
+        address: {
+          line1: "5595 Shannon Avenue Southeast",
+          line2: null,
+          city: "Salem",
+          state: "OR",
+          postal_code: "97306",
+          country: "US",
+        },
+      },
+      shipping_details: null,
+    } as CheckoutSessionAddressSource);
+    expect(snap.billing?.city).toBe("Salem");
+    expect(snap.shipping?.line1).toBe("5595 Shannon Avenue Southeast");
+    expect(snap.shipping?.city).toBe("Salem");
+  });
+
+  it("addressesEqual normalizes comparison", () => {
+    expect(
+      addressesEqual(
+        {
+          line1: " 1 Main ",
+          city: "austin",
+          state: "tx",
+          postalCode: "78701",
+        },
+        {
+          line1: "1 main",
+          city: "Austin",
+          state: "TX",
+          postalCode: "78701",
+        }
+      )
+    ).toBe(true);
+  });
+
+  it("phonesEqual strips non-digits", () => {
+    expect(phonesEqual("(555) 010-2345", "5550102345")).toBe(true);
+  });
+
+  it("customerAddressesFullyBlank is true only when both empty", () => {
+    const blank = {
+      id: 1,
+      billingAddressLine1: null,
+      billingCity: null,
+      billingState: null,
+      billingPostalCode: null,
+      shippingAddressLine1: null,
+      shippingCity: null,
+    } as unknown as Customer;
+
+    const withShip = {
+      ...blank,
+      shippingAddressLine1: "x",
+    } as unknown as Customer;
+
+    expect(customerAddressesFullyBlank(blank)).toBe(true);
+    expect(customerAddressesFullyBlank(withShip)).toBe(false);
+  });
+
+  it("customerAddressesFullyBlank is true when only default countries on file", () => {
+    const countryOnly = {
+      id: 1,
+      billingAddressLine1: null,
+      billingCity: null,
+      billingState: null,
+      billingPostalCode: null,
+      billingCountry: "US",
+      shippingAddressLine1: null,
+      shippingCity: null,
+      shippingState: null,
+      shippingPostalCode: null,
+      shippingCountry: "US",
+    } as unknown as Customer;
+    expect(customerAddressesFullyBlank(countryOnly)).toBe(true);
+  });
+
+  it("snapshotToPartialCustomerInput builds customer patch", () => {
+    const patch = snapshotToPartialCustomerInput({
+      billing: {
+        line1: "1 B",
+        line2: null,
+        city: "C",
+        state: "S",
+        postalCode: "12345",
+        country: "US",
+      },
+      shipping: null,
+      phone: "+15550001111",
+    });
+
+    expect(patch.billingAddressLine1).toBe("1 B");
+    expect(patch.phone).toBe("+15550001111");
+    expect(patch.shippingAddressLine1).toBeUndefined();
+  });
+});

--- a/app/lib/stripe/checkout-addresses.server.ts
+++ b/app/lib/stripe/checkout-addresses.server.ts
@@ -1,0 +1,761 @@
+import type Stripe from "stripe";
+import { eq } from "drizzle-orm";
+import { db } from "~/lib/db";
+import { quotes } from "~/lib/db/schema";
+import type { Customer } from "~/lib/db/schema";
+import {
+  extractBillingAddress,
+  extractShippingAddress,
+  formatAddress,
+  isAddressEmpty,
+  isAddressMeaningfullyEmpty,
+  type Address,
+} from "~/lib/address-utils";
+import {
+  getCustomer,
+  updateCustomer,
+  type CustomerEventContext,
+  type CustomerInput,
+} from "~/lib/customers";
+import { getStripeClient } from "~/lib/stripe.server";
+import { isStripePaymentLinksEnabled } from "~/lib/featureFlags";
+import type { CheckoutAddressConflictPreview } from "~/lib/stripe/checkout-address-conflict.types";
+
+/** Domain-stable snapshot (no Stripe types exported to callers). */
+export type CheckoutAddressFields = {
+  line1: string | null;
+  line2: string | null;
+  city: string | null;
+  state: string | null;
+  postalCode: string | null;
+  country: string | null;
+};
+
+export type CheckoutAddressSnapshot = {
+  billing: CheckoutAddressFields | null;
+  shipping: CheckoutAddressFields | null;
+  phone: string | null;
+};
+
+function normToken(s: string | null | undefined): string {
+  return (s ?? "").trim().toLowerCase().replace(/\s+/g, " ");
+}
+
+export function addressesEqual(a: Address, b: Address): boolean {
+  return (
+    normToken(a.line1) === normToken(b.line1) &&
+    normToken(a.line2) === normToken(b.line2) &&
+    normToken(a.city) === normToken(b.city) &&
+    normToken(a.state) === normToken(b.state) &&
+    normToken(a.postalCode) === normToken(b.postalCode) &&
+    normToken(a.country || "US") === normToken(b.country || "US")
+  );
+}
+
+export function phonesEqual(a: string | null, b: string | null): boolean {
+  const da = (a ?? "").replace(/\D/g, "");
+  const db = (b ?? "").replace(/\D/g, "");
+  if (!da && !db) return true;
+  return da === db;
+}
+
+function addressFieldsToAddress(f: CheckoutAddressFields | null): Address {
+  if (!f) {
+    return {
+      line1: null,
+      line2: null,
+      city: null,
+      state: null,
+      postalCode: null,
+      country: null,
+    };
+  }
+  return {
+    line1: f.line1,
+    line2: f.line2,
+    city: f.city,
+    state: f.state,
+    postalCode: f.postalCode,
+    country: f.country,
+  };
+}
+
+function hasAnyAddressField(f: CheckoutAddressFields | null): boolean {
+  return !isAddressEmpty(addressFieldsToAddress(f));
+}
+
+export function mapStripeAddressToFields(
+  addr: Stripe.Address | null | undefined
+): CheckoutAddressFields | null {
+  if (!addr) return null;
+  const line1 = addr.line1 ?? null;
+  const line2 = addr.line2 ?? null;
+  const city = addr.city ?? null;
+  const state = addr.state ?? null;
+  const postalCode = addr.postal_code ?? null;
+  const country = addr.country ?? null;
+  if (!line1 && !line2 && !city && !state && !postalCode && !country) {
+    return null;
+  }
+  return { line1, line2, city, state, postalCode, country };
+}
+
+/** Narrow shape from Checkout Session used for address import. */
+export type CheckoutSessionAddressSource = {
+  customer_details?: Stripe.Checkout.Session.CustomerDetails | null;
+  /**
+   * Newer Stripe Checkout Sessions expose shipping under collected_information.
+   * Prefer this over legacy `shipping_details` when both are present.
+   */
+  collected_information?: Stripe.Checkout.Session.CollectedInformation | null;
+  /** Legacy field; may still appear on some API responses. */
+  shipping_details?: {
+    address?: Stripe.Address | null;
+    phone?: string | null;
+  } | null;
+};
+
+/** Maps a retrieved Checkout Session to our snapshot (unit-testable). */
+export function mapStripeSessionToSnapshot(
+  session: CheckoutSessionAddressSource
+): CheckoutAddressSnapshot {
+  const billingRaw = session.customer_details?.address;
+  const billing = mapStripeAddressToFields(billingRaw);
+
+  const shipAddrFromCollected =
+    session.collected_information?.shipping_details?.address;
+  const shipAddrLegacy = session.shipping_details?.address;
+  const shipAddr = shipAddrFromCollected ?? shipAddrLegacy;
+
+  let shipping = mapStripeAddressToFields(shipAddr);
+
+  // When checkout collects shipping but Stripe omits a distinct shipping payload
+  // (same physical address as billing), reuse billing for shipping.
+  if (!shipping && billing) {
+    shipping = {
+      line1: billing.line1,
+      line2: billing.line2,
+      city: billing.city,
+      state: billing.state,
+      postalCode: billing.postalCode,
+      country: billing.country,
+    };
+  }
+
+  const phone =
+    session.customer_details?.phone?.trim() ||
+    String(session.shipping_details?.phone ?? "").trim() ||
+    null;
+
+  return {
+    billing,
+    shipping,
+    phone: phone || null,
+  };
+}
+
+function fieldsToBillingInput(
+  f: CheckoutAddressFields
+): Pick<
+  CustomerInput,
+  | "billingAddressLine1"
+  | "billingAddressLine2"
+  | "billingCity"
+  | "billingState"
+  | "billingPostalCode"
+  | "billingCountry"
+> {
+  return {
+    billingAddressLine1: f.line1,
+    billingAddressLine2: f.line2,
+    billingCity: f.city,
+    billingState: f.state,
+    billingPostalCode: f.postalCode,
+    billingCountry: f.country ?? "US",
+  };
+}
+
+function fieldsToShippingInput(
+  f: CheckoutAddressFields
+): Pick<
+  CustomerInput,
+  | "shippingAddressLine1"
+  | "shippingAddressLine2"
+  | "shippingCity"
+  | "shippingState"
+  | "shippingPostalCode"
+  | "shippingCountry"
+> {
+  return {
+    shippingAddressLine1: f.line1,
+    shippingAddressLine2: f.line2,
+    shippingCity: f.city,
+    shippingState: f.state,
+    shippingPostalCode: f.postalCode,
+    shippingCountry: f.country ?? "US",
+  };
+}
+
+export function snapshotToPartialCustomerInput(
+  snapshot: CheckoutAddressSnapshot
+): Partial<CustomerInput> {
+  const out: Partial<CustomerInput> = {};
+  if (snapshot.billing && hasAnyAddressField(snapshot.billing)) {
+    Object.assign(out, fieldsToBillingInput(snapshot.billing));
+  }
+  if (snapshot.shipping && hasAnyAddressField(snapshot.shipping)) {
+    Object.assign(out, fieldsToShippingInput(snapshot.shipping));
+  }
+  if (snapshot.phone) {
+    out.phone = snapshot.phone;
+  }
+  return out;
+}
+
+export function customerAddressesFullyBlank(customer: Customer): boolean {
+  return (
+    isAddressMeaningfullyEmpty(extractBillingAddress(customer)) &&
+    isAddressMeaningfullyEmpty(extractShippingAddress(customer))
+  );
+}
+
+async function getQuoteStripeLinkRow(quoteId: number): Promise<{
+  stripePaymentLinkId: string | null;
+  quoteNumber: string;
+} | null> {
+  const [row] = await db
+    .select({
+      stripePaymentLinkId: quotes.stripePaymentLinkId,
+      quoteNumber: quotes.quoteNumber,
+    })
+    .from(quotes)
+    .where(eq(quotes.id, quoteId))
+    .limit(1);
+  return row ?? null;
+}
+
+/**
+ * Latest completed Checkout Session for this Payment Link.
+ */
+export async function fetchCheckoutSnapshotForPaymentLink(
+  paymentLinkId: string
+): Promise<CheckoutAddressSnapshot | null> {
+  const stripe = getStripeClient();
+  if (!stripe) return null;
+
+  const list = await stripe.checkout.sessions.list({
+    payment_link: paymentLinkId,
+    status: "complete",
+    limit: 24,
+  });
+
+  if (!list.data.length) return null;
+
+  const sorted = [...list.data].sort((a, b) => b.created - a.created);
+  const latestId = sorted[0]!.id;
+  const session = await stripe.checkout.sessions.retrieve(latestId);
+  return mapStripeSessionToSnapshot(session as CheckoutSessionAddressSource);
+}
+
+export type CheckoutImportPreviewReason =
+  | "flag_off"
+  | "not_configured"
+  | "no_source_quote"
+  | "no_customer"
+  | "no_payment_link"
+  | "no_completed_checkout"
+  | "stripe_error"
+  | "already_matches";
+
+export type CheckoutImportPreview =
+  | { ok: false; reason: CheckoutImportPreviewReason; message: string }
+  | {
+      ok: true;
+      mode: "auto_apply";
+      patch: Partial<CustomerInput>;
+      quoteId: number;
+      quoteNumber: string;
+    }
+  | {
+      ok: true;
+      mode: "conflict";
+      quoteId: number;
+      quoteNumber: string;
+      stripe: CheckoutAddressSnapshot;
+      onFileBilling: Address;
+      onFileShipping: Address;
+      onFilePhone: string | null;
+      /** User must choose for each true key before apply */
+      chooseBilling: boolean;
+      chooseShipping: boolean;
+      choosePhone: boolean;
+      /** Human-readable blocks for modal */
+      stripeBillingText: string;
+      stripeShippingText: string;
+      onFileBillingText: string;
+      onFileShippingText: string;
+      stripePhone: string | null;
+    };
+
+function snapshotHasImportableData(snapshot: CheckoutAddressSnapshot): boolean {
+  return (
+    hasAnyAddressField(snapshot.billing) ||
+    hasAnyAddressField(snapshot.shipping) ||
+    !!snapshot.phone
+  );
+}
+
+export function checkoutConflictPreviewToModalPayload(
+  p: Extract<CheckoutImportPreview, { ok: true; mode: "conflict" }>
+): CheckoutAddressConflictPreview {
+  return {
+    quoteId: p.quoteId,
+    quoteNumber: p.quoteNumber,
+    chooseBilling: p.chooseBilling,
+    chooseShipping: p.chooseShipping,
+    choosePhone: p.choosePhone,
+    stripeBillingText: p.stripeBillingText,
+    stripeShippingText: p.stripeShippingText,
+    onFileBillingText: p.onFileBillingText,
+    onFileShippingText: p.onFileShippingText,
+    stripePhone: p.stripePhone,
+    onFilePhone: p.onFilePhone,
+  };
+}
+
+export async function previewCheckoutAddressImportForOrder(params: {
+  orderId: number;
+  sourceQuoteId: number | null;
+  customerId: number | null;
+}): Promise<CheckoutImportPreview> {
+  const flagOn = await isStripePaymentLinksEnabled();
+  if (!flagOn) {
+    return {
+      ok: false,
+      reason: "flag_off",
+      message: "Quote payment checkout import is not enabled.",
+    };
+  }
+  if (!getStripeClient()) {
+    return {
+      ok: false,
+      reason: "not_configured",
+      message: "Payment checkout is not configured.",
+    };
+  }
+  if (!params.sourceQuoteId) {
+    return {
+      ok: false,
+      reason: "no_source_quote",
+      message: "This order has no source quote.",
+    };
+  }
+  if (!params.customerId) {
+    return {
+      ok: false,
+      reason: "no_customer",
+      message: "This order has no customer.",
+    };
+  }
+
+  const qrow = await getQuoteStripeLinkRow(params.sourceQuoteId);
+  if (!qrow?.stripePaymentLinkId) {
+    return {
+      ok: false,
+      reason: "no_payment_link",
+      message: "This quote has no payment link to read from.",
+    };
+  }
+
+  let snapshot: CheckoutAddressSnapshot | null;
+  try {
+    snapshot = await fetchCheckoutSnapshotForPaymentLink(
+      qrow.stripePaymentLinkId
+    );
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return {
+      ok: false,
+      reason: "stripe_error",
+      message: msg,
+    };
+  }
+
+  if (!snapshot || !snapshotHasImportableData(snapshot)) {
+    return {
+      ok: false,
+      reason: "no_completed_checkout",
+      message:
+        "No completed payment checkout found yet for this quote’s link.",
+    };
+  }
+
+  const customer = await getCustomer(params.customerId);
+  if (!customer) {
+    return {
+      ok: false,
+      reason: "no_customer",
+      message: "Customer not found.",
+    };
+  }
+
+  const billingOnFile = extractBillingAddress(customer);
+  const shippingOnFile = extractShippingAddress(customer);
+  const phoneOnFile = customer.phone?.trim() || null;
+
+  if (customerAddressesFullyBlank(customer)) {
+    const patch = snapshotToPartialCustomerInput(snapshot);
+    if (Object.keys(patch).length === 0) {
+      return {
+        ok: false,
+        reason: "no_completed_checkout",
+        message: "Checkout did not include any address or phone to import.",
+      };
+    }
+    return {
+      ok: true,
+      mode: "auto_apply",
+      patch,
+      quoteId: params.sourceQuoteId,
+      quoteNumber: qrow.quoteNumber,
+    };
+  }
+
+  const stripeBillingAddr = addressFieldsToAddress(snapshot.billing);
+  const stripeShippingAddr = addressFieldsToAddress(snapshot.shipping);
+
+  const chooseBilling =
+    hasAnyAddressField(snapshot.billing) &&
+    !isAddressMeaningfullyEmpty(billingOnFile) &&
+    !addressesEqual(stripeBillingAddr, billingOnFile);
+
+  const chooseShipping =
+    hasAnyAddressField(snapshot.shipping) &&
+    !isAddressMeaningfullyEmpty(shippingOnFile) &&
+    !addressesEqual(stripeShippingAddr, shippingOnFile);
+
+  const choosePhone =
+    !!snapshot.phone &&
+    !!phoneOnFile &&
+    !phonesEqual(snapshot.phone, phoneOnFile);
+
+  const stripeBillingText = snapshot.billing
+    ? formatAddress(addressFieldsToAddress(snapshot.billing))
+    : "";
+  const stripeShippingText = snapshot.shipping
+    ? formatAddress(addressFieldsToAddress(snapshot.shipping))
+    : "";
+  const onFileBillingText = formatAddress(billingOnFile);
+  const onFileShippingText = formatAddress(shippingOnFile);
+
+  if (!chooseBilling && !chooseShipping && !choosePhone) {
+    const passivePatch = mergeConflictApply({
+      customer,
+      snapshot,
+      billingChoice: "on_file",
+      shippingChoice: "on_file",
+      phoneChoice: "on_file",
+      chooseBilling: false,
+      chooseShipping: false,
+      choosePhone: false,
+    });
+    if (Object.keys(passivePatch).length === 0) {
+      return {
+        ok: false,
+        reason: "already_matches",
+        message: "Customer already matches the checkout information.",
+      };
+    }
+    return {
+      ok: true,
+      mode: "auto_apply",
+      patch: passivePatch,
+      quoteId: params.sourceQuoteId,
+      quoteNumber: qrow.quoteNumber,
+    };
+  }
+
+  return {
+    ok: true,
+    mode: "conflict",
+    quoteId: params.sourceQuoteId,
+    quoteNumber: qrow.quoteNumber,
+    stripe: snapshot,
+    onFileBilling: billingOnFile,
+    onFileShipping: shippingOnFile,
+    onFilePhone: phoneOnFile,
+    chooseBilling,
+    chooseShipping,
+    choosePhone,
+    stripeBillingText,
+    stripeShippingText,
+    onFileBillingText,
+    onFileShippingText,
+    stripePhone: snapshot.phone,
+  };
+}
+
+function mergeConflictApply(params: {
+  customer: Customer;
+  snapshot: CheckoutAddressSnapshot;
+  billingChoice: "checkout" | "on_file";
+  shippingChoice: "checkout" | "on_file";
+  phoneChoice: "checkout" | "on_file";
+  chooseBilling: boolean;
+  chooseShipping: boolean;
+  choosePhone: boolean;
+}): Partial<CustomerInput> {
+  const {
+    customer,
+    snapshot,
+    billingChoice,
+    shippingChoice,
+    phoneChoice,
+    chooseBilling,
+    chooseShipping,
+    choosePhone,
+  } = params;
+  const patch: Partial<CustomerInput> = {};
+
+  const billingOnFile = extractBillingAddress(customer);
+  const shippingOnFile = extractShippingAddress(customer);
+  const phoneOnFile = customer.phone?.trim() || null;
+
+  // Billing
+  if (hasAnyAddressField(snapshot.billing)) {
+    if (chooseBilling) {
+      if (billingChoice === "checkout") {
+        Object.assign(patch, fieldsToBillingInput(snapshot.billing!));
+      }
+      // on_file: omit (keep existing)
+    } else if (isAddressMeaningfullyEmpty(billingOnFile)) {
+      Object.assign(patch, fieldsToBillingInput(snapshot.billing!));
+    }
+  }
+
+  // Shipping
+  if (hasAnyAddressField(snapshot.shipping)) {
+    if (chooseShipping) {
+      if (shippingChoice === "checkout") {
+        Object.assign(patch, fieldsToShippingInput(snapshot.shipping!));
+      }
+    } else if (isAddressMeaningfullyEmpty(shippingOnFile)) {
+      Object.assign(patch, fieldsToShippingInput(snapshot.shipping!));
+    }
+  }
+
+  // Phone
+  if (snapshot.phone) {
+    if (choosePhone) {
+      if (phoneChoice === "checkout") {
+        patch.phone = snapshot.phone;
+      }
+    } else if (!phoneOnFile) {
+      patch.phone = snapshot.phone;
+    }
+  }
+
+  return patch;
+}
+
+export async function applyCheckoutAddressImportForOrder(params: {
+  orderId: number;
+  sourceQuoteId: number | null;
+  customerId: number | null;
+  /** Conflict path only */
+  billingChoice?: "checkout" | "on_file";
+  shippingChoice?: "checkout" | "on_file";
+  phoneChoice?: "checkout" | "on_file";
+  eventContext?: CustomerEventContext;
+}): Promise<
+  | { ok: true; updated: boolean }
+  | { ok: false; reason: string; message: string }
+> {
+  const preview = await previewCheckoutAddressImportForOrder({
+    orderId: params.orderId,
+    sourceQuoteId: params.sourceQuoteId,
+    customerId: params.customerId,
+  });
+
+  if (!preview.ok) {
+    return {
+      ok: false,
+      reason: preview.reason,
+      message: preview.message,
+    };
+  }
+
+  if (!params.customerId) {
+    return { ok: false, reason: "no_customer", message: "No customer." };
+  }
+
+  const customer = await getCustomer(params.customerId);
+  if (!customer) {
+    return { ok: false, reason: "no_customer", message: "Customer not found." };
+  }
+
+  let patch: Partial<CustomerInput>;
+
+  if (preview.mode === "auto_apply") {
+    patch = preview.patch;
+  } else {
+    const {
+      chooseBilling,
+      chooseShipping,
+      choosePhone,
+      stripe,
+    } = preview;
+
+    const billingChoice = params.billingChoice ?? "on_file";
+    const shippingChoice = params.shippingChoice ?? "on_file";
+    const phoneChoice = params.phoneChoice ?? "on_file";
+
+    if (
+      chooseBilling &&
+      params.billingChoice !== "checkout" &&
+      params.billingChoice !== "on_file"
+    ) {
+      return {
+        ok: false,
+        reason: "validation",
+        message: "Choose billing: checkout or on file.",
+      };
+    }
+    if (
+      chooseShipping &&
+      params.shippingChoice !== "checkout" &&
+      params.shippingChoice !== "on_file"
+    ) {
+      return {
+        ok: false,
+        reason: "validation",
+        message: "Choose shipping: checkout or on file.",
+      };
+    }
+    if (
+      choosePhone &&
+      params.phoneChoice !== "checkout" &&
+      params.phoneChoice !== "on_file"
+    ) {
+      return {
+        ok: false,
+        reason: "validation",
+        message: "Choose phone: checkout or on file.",
+      };
+    }
+
+    patch = mergeConflictApply({
+      customer,
+      snapshot: stripe,
+      billingChoice,
+      shippingChoice,
+      phoneChoice,
+      chooseBilling,
+      chooseShipping,
+      choosePhone,
+    });
+  }
+
+  if (Object.keys(patch).length === 0) {
+    return { ok: true, updated: false };
+  }
+
+  await updateCustomer(params.customerId, patch, {
+    ...params.eventContext,
+    checkoutAddressImport: {
+      quoteId: preview.quoteId,
+      orderId: params.orderId,
+      quoteNumber: preview.quoteNumber,
+    },
+  });
+
+  return { ok: true, updated: true };
+}
+
+export type QuickImportResult =
+  | { kind: "error"; message: string; reason?: string }
+  | { kind: "applied" }
+  | { kind: "noop"; message: string }
+  | { kind: "conflict"; preview: CheckoutAddressConflictPreview };
+
+/**
+ * One round trip from the order UI: auto-apply when possible, else return conflict payload for modal.
+ */
+export async function importCheckoutAddressesQuickFromOrder(params: {
+  orderId: number;
+  sourceQuoteId: number | null;
+  customerId: number | null;
+  eventContext?: CustomerEventContext;
+}): Promise<QuickImportResult> {
+  const preview = await previewCheckoutAddressImportForOrder(params);
+  if (!preview.ok) {
+    return {
+      kind: "error",
+      message: preview.message,
+      reason: preview.reason,
+    };
+  }
+  if (preview.mode === "conflict") {
+    return {
+      kind: "conflict",
+      preview: checkoutConflictPreviewToModalPayload(preview),
+    };
+  }
+  const applied = await applyCheckoutAddressImportForOrder(params);
+  if (!applied.ok) {
+    return {
+      kind: "error",
+      message: applied.message,
+      reason: applied.reason,
+    };
+  }
+  if (!applied.updated) {
+    return { kind: "noop", message: "Nothing to update." };
+  }
+  return { kind: "applied" };
+}
+
+/**
+ * Best-effort after quote→order: only blank customers; never throws.
+ */
+export async function tryAutoFillBlankCustomerFromQuoteCheckout(params: {
+  quoteId: number;
+  customerId: number;
+  orderId: number;
+  eventContext?: CustomerEventContext;
+}): Promise<void> {
+  try {
+    const flagOn = await isStripePaymentLinksEnabled();
+    if (!flagOn || !getStripeClient()) return;
+
+    const customer = await getCustomer(params.customerId);
+    if (!customer || !customerAddressesFullyBlank(customer)) return;
+
+    const qrow = await getQuoteStripeLinkRow(params.quoteId);
+    if (!qrow?.stripePaymentLinkId) return;
+
+    let snapshot: CheckoutAddressSnapshot | null;
+    try {
+      snapshot = await fetchCheckoutSnapshotForPaymentLink(
+        qrow.stripePaymentLinkId
+      );
+    } catch {
+      return;
+    }
+    if (!snapshot || !snapshotHasImportableData(snapshot)) return;
+
+    const patch = snapshotToPartialCustomerInput(snapshot);
+    if (Object.keys(patch).length === 0) return;
+
+    await updateCustomer(params.customerId, patch, {
+      ...params.eventContext,
+      checkoutAddressImport: {
+        quoteId: params.quoteId,
+        orderId: params.orderId,
+        quoteNumber: qrow.quoteNumber,
+      },
+    });
+  } catch (e) {
+    console.error("tryAutoFillBlankCustomerFromQuoteCheckout:", e);
+  }
+}

--- a/app/routes/_protected.orders.$orderId.tsx
+++ b/app/routes/_protected.orders.$orderId.tsx
@@ -31,7 +31,9 @@ import {
   isOutboundEmailEnabled,
   FEATURE_FLAGS,
   canUserUploadCadRevision,
+  isStripePaymentLinksEnabled,
 } from "~/lib/featureFlags";
+import { isStripeConfigured } from "~/lib/stripe.server";
 import { EMAIL_CONTEXT } from "~/lib/email/email-context-registry";
 import {
   handleEmailPreviewAction,
@@ -54,6 +56,11 @@ import Breadcrumbs from "~/components/Breadcrumbs";
 import FileViewerModal from "~/components/shared/FileViewerModal";
 import { Notes } from "~/components/shared/Notes";
 import OrderActionsDropdown from "~/components/orders/OrderActionsDropdown";
+import CheckoutAddressConflictModal, {
+  type CheckoutAddressImportPhase,
+  type CheckoutAddressImportProgressStep,
+} from "~/components/orders/CheckoutAddressConflictModal";
+import type { CheckoutAddressConflictPreview } from "~/lib/stripe/checkout-address-conflict.types";
 import SendOrderConfirmationModal from "~/components/orders/SendOrderConfirmationModal";
 import GeneratePurchaseOrderPdfModal from "~/components/orders/GeneratePurchaseOrderPdfModal";
 import GenerateInvoicePdfModal from "~/components/orders/GenerateInvoicePdfModal";
@@ -86,6 +93,7 @@ import {
   attachments,
   partDrawings,
   orderLineItems,
+  quotes,
 } from "~/lib/db/schema";
 import { eq } from "drizzle-orm";
 import {
@@ -321,6 +329,19 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     }
   }
 
+  const stripePaymentLinksEnabled = await isStripePaymentLinksEnabled();
+  const stripeConfigured = isStripeConfigured();
+
+  let quoteStripePaymentLinkId: string | null = null;
+  if (order.sourceQuoteId) {
+    const [qr] = await db
+      .select({ stripePaymentLinkId: quotes.stripePaymentLinkId })
+      .from(quotes)
+      .where(eq(quotes.id, order.sourceQuoteId))
+      .limit(1);
+    quoteStripePaymentLinkId = qr?.stripePaymentLinkId ?? null;
+  }
+
   return withAuthHeaders(
     json({
       order,
@@ -343,6 +364,9 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
       orderConfirmationEditableSlots,
       orderConfirmationRequiredAttachmentDocumentKinds,
       orderConfirmationSendBlocked,
+      stripePaymentLinksEnabled,
+      stripeConfigured,
+      quoteStripePaymentLinkId,
     }),
     headers
   );
@@ -389,6 +413,8 @@ export async function action({ request, params }: ActionFunctionArgs) {
         "emailPreview",
         "emailQueue",
         "addDrawingToPart", // Drawing uploads use drawing_0, drawing_1, etc. fields
+        "importCheckoutAddressesQuick",
+        "applyCheckoutAddressImportChoices",
       ];
       if (specialIntents.includes(intent)) {
         // These intents handle form data differently, let them fall through
@@ -1573,6 +1599,57 @@ export async function action({ request, params }: ActionFunctionArgs) {
         return json({ success: true });
       }
 
+      case "importCheckoutAddressesQuick": {
+        const { importCheckoutAddressesQuickFromOrder } = await import(
+          "~/lib/stripe/checkout-addresses.server"
+        );
+        const result = await importCheckoutAddressesQuickFromOrder({
+          orderId: order.id,
+          sourceQuoteId: order.sourceQuoteId ?? null,
+          customerId: order.customerId ?? null,
+          eventContext: {
+            userId: user?.id,
+            userEmail: user?.email || userDetails?.name || undefined,
+          },
+        });
+        return withAuthHeaders(json(result), headers);
+      }
+
+      case "applyCheckoutAddressImportChoices": {
+        const { applyCheckoutAddressImportForOrder } = await import(
+          "~/lib/stripe/checkout-addresses.server"
+        );
+        const parseChoice = (key: string) => {
+          const v = formData.get(key);
+          return v === "checkout" || v === "on_file" ? v : undefined;
+        };
+        const result = await applyCheckoutAddressImportForOrder({
+          orderId: order.id,
+          sourceQuoteId: order.sourceQuoteId ?? null,
+          customerId: order.customerId ?? null,
+          billingChoice: parseChoice("billingChoice"),
+          shippingChoice: parseChoice("shippingChoice"),
+          phoneChoice: parseChoice("phoneChoice"),
+          eventContext: {
+            userId: user?.id,
+            userEmail: user?.email || userDetails?.name || undefined,
+          },
+        });
+        if (!result.ok) {
+          return withAuthHeaders(
+            json(
+              { error: result.message, reason: result.reason },
+              { status: 400 }
+            ),
+            headers
+          );
+        }
+        return withAuthHeaders(
+          json({ success: true, updated: result.updated }),
+          headers
+        );
+      }
+
       default:
         return json({ error: "Invalid intent" }, { status: 400 });
     }
@@ -1604,6 +1681,9 @@ export default function OrderDetails() {
     orderConfirmationEditableSlots,
     orderConfirmationRequiredAttachmentDocumentKinds,
     orderConfirmationSendBlocked,
+    stripePaymentLinksEnabled,
+    stripeConfigured,
+    quoteStripePaymentLinkId,
   } = useLoaderData<typeof loader>();
   const partAssetAdminAction = usePartAssetAdminAccess()
     ? `/orders/${order.orderNumber}`
@@ -1662,6 +1742,41 @@ export default function OrderDetails() {
   const [isPackingSlipModalOpen, setIsPackingSlipModalOpen] = useState(false);
   const [isSendOrderConfirmationModalOpen, setSendOrderConfirmationModalOpen] =
     useState(false);
+  const [checkoutAddressModalOpen, setCheckoutAddressModalOpen] =
+    useState(false);
+  const [checkoutAddressPhase, setCheckoutAddressPhase] =
+    useState<CheckoutAddressImportPhase>("working");
+  const [checkoutAddressStep, setCheckoutAddressStep] =
+    useState<CheckoutAddressImportProgressStep>("connecting");
+  const [checkoutConflictPreview, setCheckoutConflictPreview] = useState<
+    CheckoutAddressConflictPreview | null
+  >(null);
+  const [checkoutErrorMessage, setCheckoutErrorMessage] = useState<
+    string | undefined
+  >(undefined);
+  const [checkoutSummary, setCheckoutSummary] = useState<{
+    billingUpdated?: boolean;
+    shippingUpdated?: boolean;
+    phoneUpdated?: boolean;
+  }>({});
+  const checkoutAddressImportFetcher = useFetcher();
+  const lastCheckoutChoicesRef = useRef<{
+    billingChoice?: "checkout" | "on_file";
+    shippingChoice?: "checkout" | "on_file";
+    phoneChoice?: "checkout" | "on_file";
+  } | null>(null);
+
+  const showImportCheckoutAddresses =
+    stripePaymentLinksEnabled && !!quoteStripePaymentLinkId;
+
+  const importCheckoutAddressesDisabled =
+    !order.customerId || !stripeConfigured;
+
+  const importCheckoutAddressesTooltip = !order.customerId
+    ? "Orders need a customer to import addresses."
+    : !stripeConfigured
+      ? "Payment checkout is not configured."
+      : "";
 
   const canSendOrderConfirmation =
     outboundEmailEnabled &&
@@ -2042,6 +2157,131 @@ export default function OrderDetails() {
     }
   };
 
+  useEffect(() => {
+    if (!checkoutAddressModalOpen) return;
+    if (checkoutAddressImportFetcher.state === "submitting") {
+      setCheckoutAddressStep("fetching");
+      return;
+    }
+    if (checkoutAddressImportFetcher.state === "loading") {
+      setCheckoutAddressStep("comparing");
+    }
+  }, [checkoutAddressImportFetcher.state, checkoutAddressModalOpen]);
+
+  useEffect(() => {
+    if (!checkoutAddressModalOpen) return;
+    if (checkoutAddressImportFetcher.state !== "idle") return;
+    const d = checkoutAddressImportFetcher.data as
+      | {
+          kind?: string;
+          message?: string;
+          reason?: string;
+          preview?: CheckoutAddressConflictPreview;
+          success?: boolean;
+          updated?: boolean;
+          error?: string;
+        }
+      | undefined;
+    if (!d) return;
+
+    if (d.kind === "error" || d.error) {
+      setCheckoutErrorMessage(d.message ?? d.error ?? "Import failed.");
+      setCheckoutAddressPhase("error");
+      return;
+    }
+
+    if (d.kind === "applied") {
+      const choices = lastCheckoutChoicesRef.current;
+      lastCheckoutChoicesRef.current = null;
+      setCheckoutSummary(
+        choices
+          ? {
+              billingUpdated: choices.billingChoice === "checkout",
+              shippingUpdated: choices.shippingChoice === "checkout",
+              phoneUpdated: choices.phoneChoice === "checkout",
+            }
+          : { billingUpdated: true, shippingUpdated: true, phoneUpdated: true }
+      );
+      setCheckoutAddressPhase("success");
+      revalidator.revalidate();
+      return;
+    }
+
+    if (d.kind === "noop") {
+      setCheckoutErrorMessage(d.message);
+      setCheckoutAddressPhase("noop");
+      return;
+    }
+
+    if (d.kind === "conflict" && d.preview) {
+      setCheckoutConflictPreview(d.preview);
+      setCheckoutAddressPhase("conflict");
+      return;
+    }
+
+    if (d.success === true && typeof d.updated === "boolean") {
+      const choices = lastCheckoutChoicesRef.current;
+      lastCheckoutChoicesRef.current = null;
+      if (d.updated) {
+        setCheckoutSummary({
+          billingUpdated: choices?.billingChoice === "checkout",
+          shippingUpdated: choices?.shippingChoice === "checkout",
+          phoneUpdated: choices?.phoneChoice === "checkout",
+        });
+        setCheckoutAddressPhase("success");
+        revalidator.revalidate();
+      } else {
+        setCheckoutAddressPhase("noop");
+      }
+    }
+  }, [
+    checkoutAddressImportFetcher.state,
+    checkoutAddressImportFetcher.data,
+    checkoutAddressModalOpen,
+    revalidator,
+  ]);
+
+  const startCheckoutAddressImport = () => {
+    setCheckoutErrorMessage(undefined);
+    setCheckoutConflictPreview(null);
+    setCheckoutSummary({});
+    setCheckoutAddressStep("connecting");
+    setCheckoutAddressPhase("working");
+    setCheckoutAddressModalOpen(true);
+    const fd = new FormData();
+    fd.append("intent", "importCheckoutAddressesQuick");
+    checkoutAddressImportFetcher.submit(fd, { method: "post" });
+  };
+
+  const handleImportCheckoutAddresses = () => {
+    if (importCheckoutAddressesDisabled) return;
+    startCheckoutAddressImport();
+  };
+
+  const handleCloseCheckoutAddressModal = () => {
+    setCheckoutAddressModalOpen(false);
+    setCheckoutConflictPreview(null);
+    setCheckoutErrorMessage(undefined);
+  };
+
+  const handleCheckoutConflictConfirm = (choices: {
+    billingChoice?: "checkout" | "on_file";
+    shippingChoice?: "checkout" | "on_file";
+    phoneChoice?: "checkout" | "on_file";
+  }) => {
+    lastCheckoutChoicesRef.current = choices;
+    setCheckoutAddressPhase("submitting_choices");
+    setCheckoutAddressStep("applying");
+    const fd = new FormData();
+    fd.append("intent", "applyCheckoutAddressImportChoices");
+    if (choices.billingChoice)
+      fd.append("billingChoice", choices.billingChoice);
+    if (choices.shippingChoice)
+      fd.append("shippingChoice", choices.shippingChoice);
+    if (choices.phoneChoice) fd.append("phoneChoice", choices.phoneChoice);
+    checkoutAddressImportFetcher.submit(fd, { method: "post" });
+  };
+
   const handleManageVendorSubmit = () => {
     const formData = new FormData();
     formData.append("intent", "updateVendor");
@@ -2364,6 +2604,14 @@ export default function OrderDetails() {
                 }
                 orderConfirmationMenuDisabled={
                   !canSendOrderConfirmation
+                }
+                onImportCheckoutAddresses={handleImportCheckoutAddresses}
+                showImportCheckoutAddresses={showImportCheckoutAddresses}
+                importCheckoutAddressesDisabled={
+                  importCheckoutAddressesDisabled
+                }
+                importCheckoutAddressesTooltip={
+                  importCheckoutAddressesTooltip
                 }
               />
             </div>
@@ -3001,6 +3249,18 @@ export default function OrderDetails() {
         lineItems={lineItems.map((item: LineItemWithPart) => item.lineItem)}
         parts={lineItems.map((item: LineItemWithPart) => item.part)}
         autoDownload={pdfAutoDownload}
+      />
+
+      <CheckoutAddressConflictModal
+        open={checkoutAddressModalOpen}
+        phase={checkoutAddressPhase}
+        progressStep={checkoutAddressStep}
+        preview={checkoutConflictPreview}
+        summary={checkoutSummary}
+        errorMessage={checkoutErrorMessage}
+        onClose={handleCloseCheckoutAddressModal}
+        onConfirm={handleCheckoutConflictConfirm}
+        onRetry={startCheckoutAddressImport}
       />
 
       {outboundEmailEnabled && isSendOrderConfirmationModalOpen && (


### PR DESCRIPTION
## What changed?

Read addresses from completed Checkout Sessions tied to the quote’s Payment Link, merge them onto the customer with safe rules (narrow auto-import on quote -> order when the customer’s addresses are fully blank, manual order action + conflict modal for every other case), and audit only when we actually write.

Also 3 bugfixes:
- Change useLayoutEffect to useEffect in server components

- Correct the broken "Bill To" field in the invoice template

- Change quote PDF to actual addresses instead of placeholders.

## Type

- [x] Bug fix
- [x] New feature
- [ ] Refactor/cleanup
- [ ] Other

## Related issue

Closes #129 

## Checklist

- [x] Tested locally
- [x] No lint/type errors
- [x] Ready for review
