### PR TITLE
Add clipboard image paste uploads for attachments

### DIFF
--- a/app/components/shared/AttachmentsSection.tsx
+++ b/app/components/shared/AttachmentsSection.tsx
@@ -1,10 +1,24 @@
-import { useRef, useState } from "react";
-import { useFetcher } from "@remix-run/react";
+import { useEffect, useRef, useState } from "react";
+import { useFetcher, useRevalidator } from "@remix-run/react";
 import Button from "./Button";
 import FileViewerModal from "./FileViewerModal";
+import { PasteAttachmentModal } from "./PasteAttachmentModal";
 import { SectionCard } from "./SectionCard";
 import { useDownload } from "~/hooks/useDownload";
+import {
+  defaultScreenshotFileName,
+  extractImageFromClipboardEvent,
+  isEditablePasteTarget,
+} from "~/lib/clipboard-images";
 import { formatFileSize, getFileType, isViewableFile } from "~/lib/file-utils";
+
+const MAX_ATTACHMENT_SIZE = 10 * 1024 * 1024;
+
+type UploadFetcherData = {
+  success?: boolean;
+  attachmentId?: string;
+  error?: string;
+};
 
 type AttachmentItem = {
   id: string;
@@ -32,10 +46,16 @@ export function AttachmentsSection({
   onDeleteOverride,
 }: AttachmentsSectionProps) {
   const { download } = useDownload();
-  const uploadFetcher = useFetcher();
+  const revalidator = useRevalidator();
+  const uploadFetcher = useFetcher<UploadFetcherData>();
   const deleteFetcher = useFetcher();
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const handledUploadIdRef = useRef<string | null>(null);
   const [fileModalOpen, setFileModalOpen] = useState(false);
+  const [pasteModalOpen, setPasteModalOpen] = useState(false);
+  const [pastedFile, setPastedFile] = useState<File | null>(null);
+  const [pastedFileName, setPastedFileName] = useState("");
+  const [pasteError, setPasteError] = useState<string | null>(null);
   const [selectedFile, setSelectedFile] = useState<{
     url: string;
     fileName: string;
@@ -54,6 +74,8 @@ export function AttachmentsSection({
 
     const formData = new FormData();
     formData.append("file", file);
+    formData.append("intent", "uploadAttachment");
+    formData.append("_noRedirect", "1");
     formData.append("entityType", String(entityType));
     formData.append("entityId", String(entityId));
 
@@ -63,6 +85,33 @@ export function AttachmentsSection({
     });
 
     event.target.value = "";
+  };
+
+  const handlePastedUpload = (fileName: string) => {
+    if (!pastedFile) return;
+
+    if (pastedFile.size > MAX_ATTACHMENT_SIZE) {
+      setPasteError("File size exceeds 10MB limit");
+      return;
+    }
+
+    const renamedFile = new File([pastedFile], fileName, {
+      type: pastedFile.type || "image/png",
+      lastModified: pastedFile.lastModified,
+    });
+
+    const formData = new FormData();
+    formData.append("file", renamedFile);
+    formData.append("intent", "uploadAttachment");
+    formData.append("_noRedirect", "1");
+    formData.append("entityType", String(entityType));
+    formData.append("entityId", String(entityId));
+
+    setPasteError(null);
+    uploadFetcher.submit(formData, {
+      method: "post",
+      encType: "multipart/form-data",
+    });
   };
 
   const handleDeleteAttachment = (attachmentId: string) => {
@@ -100,6 +149,54 @@ export function AttachmentsSection({
       day: "2-digit",
     });
   };
+
+  useEffect(() => {
+    if (readOnly) return;
+
+    const handlePaste = (event: ClipboardEvent) => {
+      if (pasteModalOpen) return;
+      if (isEditablePasteTarget(event.target)) return;
+      if (document.querySelector(".modal-overlay")) return;
+
+      const imageFile = extractImageFromClipboardEvent(event);
+      if (!imageFile) return;
+
+      event.preventDefault();
+
+      const extension = imageFile.type.split("/")[1] || "png";
+      setPastedFile(imageFile);
+      setPastedFileName(defaultScreenshotFileName(extension));
+      setPasteError(
+        imageFile.size > MAX_ATTACHMENT_SIZE ? "File size exceeds 10MB limit" : null
+      );
+      setPasteModalOpen(true);
+    };
+
+    document.addEventListener("paste", handlePaste);
+
+    return () => {
+      document.removeEventListener("paste", handlePaste);
+    };
+  }, [pasteModalOpen, readOnly]);
+
+  useEffect(() => {
+    const uploadData = uploadFetcher.data;
+    if (
+      uploadFetcher.state !== "idle" ||
+      !uploadData?.success ||
+      !uploadData.attachmentId ||
+      handledUploadIdRef.current === uploadData.attachmentId
+    ) {
+      return;
+    }
+
+    handledUploadIdRef.current = uploadData.attachmentId;
+    setPasteModalOpen(false);
+    setPastedFile(null);
+    setPastedFileName("");
+    setPasteError(null);
+    revalidator.revalidate();
+  }, [revalidator, uploadFetcher.data, uploadFetcher.state]);
 
   return (
     <>
@@ -251,6 +348,21 @@ export function AttachmentsSection({
           isDeleting={deleteFetcher.state === "submitting"}
         />
       )}
+
+      <PasteAttachmentModal
+        isOpen={pasteModalOpen}
+        file={pastedFile}
+        initialFileName={pastedFileName}
+        isUploading={uploadFetcher.state !== "idle"}
+        error={pasteError || uploadFetcher.data?.error}
+        onClose={() => {
+          setPasteModalOpen(false);
+          setPastedFile(null);
+          setPastedFileName("");
+          setPasteError(null);
+        }}
+        onUpload={handlePastedUpload}
+      />
     </>
   );
 }

--- a/app/components/shared/AttachmentsSection.tsx
+++ b/app/components/shared/AttachmentsSection.tsx
@@ -8,6 +8,8 @@ import { useDownload } from "~/hooks/useDownload";
 import {
   defaultScreenshotFileName,
   extractImageFromClipboardEvent,
+  getClipboardImageExtension,
+  getPastedImageError,
   isEditablePasteTarget,
 } from "~/lib/clipboard-images";
 import { formatFileSize, getFileType, isViewableFile } from "~/lib/file-utils";
@@ -56,6 +58,7 @@ export function AttachmentsSection({
   const [pastedFile, setPastedFile] = useState<File | null>(null);
   const [pastedFileName, setPastedFileName] = useState("");
   const [pasteError, setPasteError] = useState<string | null>(null);
+  const [uploadError, setUploadError] = useState<string | null>(null);
   const [selectedFile, setSelectedFile] = useState<{
     url: string;
     fileName: string;
@@ -90,8 +93,9 @@ export function AttachmentsSection({
   const handlePastedUpload = (fileName: string) => {
     if (!pastedFile) return;
 
-    if (pastedFile.size > MAX_ATTACHMENT_SIZE) {
-      setPasteError("File size exceeds 10MB limit");
+    const validationError = getPastedImageError(pastedFile, MAX_ATTACHMENT_SIZE);
+    if (validationError) {
+      setPasteError(validationError);
       return;
     }
 
@@ -108,6 +112,7 @@ export function AttachmentsSection({
     formData.append("entityId", String(entityId));
 
     setPasteError(null);
+    setUploadError(null);
     uploadFetcher.submit(formData, {
       method: "post",
       encType: "multipart/form-data",
@@ -163,12 +168,11 @@ export function AttachmentsSection({
 
       event.preventDefault();
 
-      const extension = imageFile.type.split("/")[1] || "png";
+      const extension = getClipboardImageExtension(imageFile.type);
       setPastedFile(imageFile);
       setPastedFileName(defaultScreenshotFileName(extension));
-      setPasteError(
-        imageFile.size > MAX_ATTACHMENT_SIZE ? "File size exceeds 10MB limit" : null
-      );
+      setPasteError(getPastedImageError(imageFile, MAX_ATTACHMENT_SIZE));
+      setUploadError(null);
       setPasteModalOpen(true);
     };
 
@@ -181,6 +185,10 @@ export function AttachmentsSection({
 
   useEffect(() => {
     const uploadData = uploadFetcher.data;
+    if (uploadFetcher.state === "idle" && uploadData?.error) {
+      setUploadError(uploadData.error);
+    }
+
     if (
       uploadFetcher.state !== "idle" ||
       !uploadData?.success ||
@@ -195,6 +203,7 @@ export function AttachmentsSection({
     setPastedFile(null);
     setPastedFileName("");
     setPasteError(null);
+    setUploadError(null);
     revalidator.revalidate();
   }, [revalidator, uploadFetcher.data, uploadFetcher.state]);
 
@@ -354,12 +363,14 @@ export function AttachmentsSection({
         file={pastedFile}
         initialFileName={pastedFileName}
         isUploading={uploadFetcher.state !== "idle"}
-        error={pasteError || uploadFetcher.data?.error}
+        error={pasteError || uploadError || undefined}
+        isUploadDisabled={Boolean(pasteError)}
         onClose={() => {
           setPasteModalOpen(false);
           setPastedFile(null);
           setPastedFileName("");
           setPasteError(null);
+          setUploadError(null);
         }}
         onUpload={handlePastedUpload}
       />

--- a/app/components/shared/PasteAttachmentModal.test.tsx
+++ b/app/components/shared/PasteAttachmentModal.test.tsx
@@ -1,0 +1,84 @@
+// @vitest-environment happy-dom
+import "@testing-library/jest-dom/vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { PasteAttachmentModal } from "./PasteAttachmentModal";
+
+function renderModal(overrides: Partial<Parameters<typeof PasteAttachmentModal>[0]> = {}) {
+  const props: Parameters<typeof PasteAttachmentModal>[0] = {
+    isOpen: true,
+    file: new File(["image"], "clipboard.png", { type: "image/png" }),
+    initialFileName: "screenshot.png",
+    isUploading: false,
+    onClose: vi.fn(),
+    onUpload: vi.fn(),
+    ...overrides,
+  };
+
+  return {
+    ...render(<PasteAttachmentModal {...props} />),
+    props,
+  };
+}
+
+describe("PasteAttachmentModal", () => {
+  beforeEach(() => {
+    vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
+      callback(0);
+      return 0;
+    });
+    vi.stubGlobal("cancelAnimationFrame", vi.fn());
+    vi.stubGlobal("URL", {
+      ...URL,
+      createObjectURL: vi.fn(() => "blob:preview-url"),
+      revokeObjectURL: vi.fn(),
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  it("submits the trimmed pasted image file name", async () => {
+    const user = userEvent.setup();
+    const onUpload = vi.fn();
+    renderModal({ initialFileName: "  pasted-image.png  ", onUpload });
+
+    await user.click(screen.getByRole("button", { name: "Upload" }));
+
+    expect(onUpload).toHaveBeenCalledWith("pasted-image.png");
+  });
+
+  it("disables upload while a validation error is shown", async () => {
+    const user = userEvent.setup();
+    const onUpload = vi.fn();
+    renderModal({
+      error: "File size exceeds 10MB limit",
+      isUploadDisabled: true,
+      onUpload,
+    });
+
+    expect(screen.getByText("File size exceeds 10MB limit")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Upload" })).toBeDisabled();
+
+    await user.click(screen.getByRole("button", { name: "Upload" }));
+
+    expect(onUpload).not.toHaveBeenCalled();
+  });
+
+  it("revokes the pasted image preview URL on unmount", () => {
+    const { unmount } = renderModal();
+
+    expect(URL.createObjectURL).toHaveBeenCalledOnce();
+    expect(screen.getByAltText("Pasted attachment preview")).toHaveAttribute(
+      "src",
+      "blob:preview-url"
+    );
+
+    unmount();
+
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:preview-url");
+  });
+});

--- a/app/components/shared/PasteAttachmentModal.tsx
+++ b/app/components/shared/PasteAttachmentModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import Button from "./Button";
 import Modal from "./Modal";
 import { formStyles } from "~/utils/tw-styles";
@@ -9,6 +9,7 @@ type PasteAttachmentModalProps = {
   initialFileName: string;
   isUploading: boolean;
   error?: string;
+  isUploadDisabled?: boolean;
   onClose: () => void;
   onUpload: (fileName: string) => void;
 };
@@ -19,11 +20,13 @@ export function PasteAttachmentModal({
   initialFileName,
   isUploading,
   error,
+  isUploadDisabled = false,
   onClose,
   onUpload,
 }: PasteAttachmentModalProps) {
   const fileNameInputRef = useRef<HTMLInputElement>(null);
   const [fileName, setFileName] = useState(initialFileName);
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
 
   useEffect(() => {
     if (isOpen) {
@@ -32,23 +35,24 @@ export function PasteAttachmentModal({
     }
   }, [initialFileName, isOpen]);
 
-  const previewUrl = useMemo(() => {
-    if (!file) return null;
-    return URL.createObjectURL(file);
-  }, [file]);
-
   useEffect(() => {
+    if (!file) {
+      setPreviewUrl(null);
+      return;
+    }
+
+    const objectUrl = URL.createObjectURL(file);
+    setPreviewUrl(objectUrl);
+
     return () => {
-      if (previewUrl) {
-        URL.revokeObjectURL(previewUrl);
-      }
+      URL.revokeObjectURL(objectUrl);
     };
-  }, [previewUrl]);
+  }, [file]);
 
   if (!file) return null;
 
   const trimmedFileName = fileName.trim();
-  const canUpload = trimmedFileName.length > 0 && !isUploading;
+  const canUpload = trimmedFileName.length > 0 && !isUploading && !isUploadDisabled;
 
   return (
     <Modal

--- a/app/components/shared/PasteAttachmentModal.tsx
+++ b/app/components/shared/PasteAttachmentModal.tsx
@@ -1,0 +1,121 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import Button from "./Button";
+import Modal from "./Modal";
+import { formStyles } from "~/utils/tw-styles";
+
+type PasteAttachmentModalProps = {
+  isOpen: boolean;
+  file: File | null;
+  initialFileName: string;
+  isUploading: boolean;
+  error?: string;
+  onClose: () => void;
+  onUpload: (fileName: string) => void;
+};
+
+export function PasteAttachmentModal({
+  isOpen,
+  file,
+  initialFileName,
+  isUploading,
+  error,
+  onClose,
+  onUpload,
+}: PasteAttachmentModalProps) {
+  const fileNameInputRef = useRef<HTMLInputElement>(null);
+  const [fileName, setFileName] = useState(initialFileName);
+
+  useEffect(() => {
+    if (isOpen) {
+      setFileName(initialFileName);
+      requestAnimationFrame(() => fileNameInputRef.current?.focus());
+    }
+  }, [initialFileName, isOpen]);
+
+  const previewUrl = useMemo(() => {
+    if (!file) return null;
+    return URL.createObjectURL(file);
+  }, [file]);
+
+  useEffect(() => {
+    return () => {
+      if (previewUrl) {
+        URL.revokeObjectURL(previewUrl);
+      }
+    };
+  }, [previewUrl]);
+
+  if (!file) return null;
+
+  const trimmedFileName = fileName.trim();
+  const canUpload = trimmedFileName.length > 0 && !isUploading;
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={isUploading ? () => undefined : onClose}
+      title="Upload Pasted Image"
+      size="lg"
+    >
+      <form
+        className="space-y-4"
+        onSubmit={(event) => {
+          event.preventDefault();
+          if (canUpload) {
+            onUpload(trimmedFileName);
+          }
+        }}
+      >
+        {previewUrl && (
+          <div className="rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900 p-3">
+            <img
+              src={previewUrl}
+              alt="Pasted attachment preview"
+              className="max-h-[50vh] w-full object-contain rounded"
+            />
+          </div>
+        )}
+
+        <div>
+          <label htmlFor="pasted-attachment-file-name" className={formStyles.label}>
+            File name
+          </label>
+          <input
+            ref={fileNameInputRef}
+            id="pasted-attachment-file-name"
+            type="text"
+            className={formStyles.input}
+            value={fileName}
+            onChange={(event) => setFileName(event.target.value)}
+            disabled={isUploading}
+          />
+        </div>
+
+        {error && (
+          <p className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700 dark:border-red-700 dark:bg-red-900/20 dark:text-red-300">
+            {error}
+          </p>
+        )}
+
+        <div className="flex items-center justify-end gap-3 pt-2">
+          <Button type="button" variant="secondary" onClick={onClose} disabled={isUploading}>
+            Cancel
+          </Button>
+          <Button type="submit" disabled={!canUpload}>
+            {isUploading ? (
+              <span className="inline-flex items-center gap-2">
+                <svg className="h-4 w-4 animate-spin" fill="none" viewBox="0 0 24 24">
+                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                </svg>
+                Uploading...
+              </span>
+            ) : (
+              "Upload"
+            )}
+          </Button>
+        </div>
+      </form>
+    </Modal>
+  );
+}

--- a/app/lib/clipboard-images.test.ts
+++ b/app/lib/clipboard-images.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  defaultScreenshotFileName,
+  extractImageFromClipboardEvent,
+  isEditablePasteTarget,
+} from "./clipboard-images";
+
+function clipboardEventWithItems(items: Array<Partial<DataTransferItem>>) {
+  return {
+    clipboardData: {
+      items,
+    },
+  } as unknown as ClipboardEvent;
+}
+
+describe("clipboard-images", () => {
+  it("extracts the first image file from a paste event", () => {
+    const screenshot = new File(["image"], "pasted.png", { type: "image/png" });
+    const event = clipboardEventWithItems([
+      { kind: "string", type: "text/plain", getAsFile: () => null },
+      { kind: "file", type: "image/png", getAsFile: () => screenshot },
+    ]);
+
+    expect(extractImageFromClipboardEvent(event)).toBe(screenshot);
+  });
+
+  it("ignores non-image clipboard files", () => {
+    const pdf = new File(["pdf"], "doc.pdf", { type: "application/pdf" });
+    const event = clipboardEventWithItems([
+      { kind: "file", type: "application/pdf", getAsFile: () => pdf },
+    ]);
+
+    expect(extractImageFromClipboardEvent(event)).toBeNull();
+  });
+
+  it("treats form fields and contenteditable elements as editable paste targets", () => {
+    expect(isEditablePasteTarget({ tagName: "INPUT" } as unknown as EventTarget)).toBe(true);
+    expect(isEditablePasteTarget({ tagName: "TEXTAREA" } as unknown as EventTarget)).toBe(true);
+    expect(isEditablePasteTarget({ tagName: "SELECT" } as unknown as EventTarget)).toBe(true);
+
+    const childOfEditable = {
+      tagName: "SPAN",
+      isContentEditable: false,
+      closest: (selector: string) => selector === "[contenteditable='true']",
+    } as unknown as EventTarget;
+
+    expect(isEditablePasteTarget(childOfEditable)).toBe(true);
+    expect(isEditablePasteTarget({ tagName: "DIV" } as unknown as EventTarget)).toBe(false);
+  });
+
+  it("formats stable screenshot file names", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-15T20:06:07"));
+
+    expect(defaultScreenshotFileName("jpeg")).toBe("screenshot-2026-06-15-200607.jpeg");
+    expect(defaultScreenshotFileName()).toBe("screenshot-2026-06-15-200607.png");
+
+    vi.useRealTimers();
+  });
+});

--- a/app/lib/clipboard-images.test.ts
+++ b/app/lib/clipboard-images.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it, vi } from "vitest";
 import {
   defaultScreenshotFileName,
   extractImageFromClipboardEvent,
+  getClipboardImageExtension,
+  getPastedImageError,
   isEditablePasteTarget,
 } from "./clipboard-images";
 
@@ -45,7 +47,30 @@ describe("clipboard-images", () => {
     } as unknown as EventTarget;
 
     expect(isEditablePasteTarget(childOfEditable)).toBe(true);
+    expect(
+      isEditablePasteTarget({
+        tagName: "SPAN",
+        isContentEditable: false,
+        closest: (selector: string) => selector === "[contenteditable]",
+      } as unknown as EventTarget)
+    ).toBe(true);
     expect(isEditablePasteTarget({ tagName: "DIV" } as unknown as EventTarget)).toBe(false);
+  });
+
+  it("normalizes clipboard image MIME subtypes into file extensions", () => {
+    expect(getClipboardImageExtension("image/png")).toBe("png");
+    expect(getClipboardImageExtension("image/jpeg")).toBe("jpeg");
+    expect(getClipboardImageExtension("image/svg+xml")).toBe("svg");
+    expect(getClipboardImageExtension("")).toBe("png");
+  });
+
+  it("validates pasted image size before upload", () => {
+    const maxSize = 10;
+
+    expect(getPastedImageError(new File(["small"], "small.png"), maxSize)).toBeNull();
+    expect(getPastedImageError(new File(["larger than ten bytes"], "large.png"), maxSize)).toBe(
+      "File size exceeds 10MB limit"
+    );
   });
 
   it("formats stable screenshot file names", () => {
@@ -53,6 +78,7 @@ describe("clipboard-images", () => {
     vi.setSystemTime(new Date("2026-06-15T20:06:07"));
 
     expect(defaultScreenshotFileName("jpeg")).toBe("screenshot-2026-06-15-200607.jpeg");
+    expect(defaultScreenshotFileName(".png")).toBe("screenshot-2026-06-15-200607.png");
     expect(defaultScreenshotFileName()).toBe("screenshot-2026-06-15-200607.png");
 
     vi.useRealTimers();

--- a/app/lib/clipboard-images.ts
+++ b/app/lib/clipboard-images.ts
@@ -1,0 +1,51 @@
+type PasteTarget = {
+  tagName?: string;
+  isContentEditable?: boolean;
+  closest?: (selector: string) => unknown;
+};
+
+export function extractImageFromClipboardEvent(event: ClipboardEvent): File | null {
+  const items = event.clipboardData?.items;
+  if (!items) return null;
+
+  for (const item of Array.from(items)) {
+    if (!item.type.startsWith("image/")) continue;
+
+    const file = item.getAsFile();
+    if (file) return file;
+  }
+
+  return null;
+}
+
+export function isEditablePasteTarget(target: EventTarget | null): boolean {
+  if (!target) return false;
+
+  const element = target as PasteTarget;
+  const tagName = element.tagName?.toUpperCase();
+
+  if (tagName === "INPUT" || tagName === "TEXTAREA" || tagName === "SELECT") {
+    return true;
+  }
+
+  if (element.isContentEditable) return true;
+
+  return Boolean(element.closest?.("[contenteditable='true']"));
+}
+
+export function defaultScreenshotFileName(extension = "png"): string {
+  const now = new Date();
+  const safeExtension = extension.replace(/^\./, "") || "png";
+  const timestamp = [
+    now.getFullYear(),
+    String(now.getMonth() + 1).padStart(2, "0"),
+    String(now.getDate()).padStart(2, "0"),
+  ].join("-");
+  const time = [
+    String(now.getHours()).padStart(2, "0"),
+    String(now.getMinutes()).padStart(2, "0"),
+    String(now.getSeconds()).padStart(2, "0"),
+  ].join("");
+
+  return `screenshot-${timestamp}-${time}.${safeExtension}`;
+}

--- a/app/lib/clipboard-images.ts
+++ b/app/lib/clipboard-images.ts
@@ -4,6 +4,8 @@ type PasteTarget = {
   closest?: (selector: string) => unknown;
 };
 
+export const PASTED_IMAGE_SIZE_ERROR = "File size exceeds 10MB limit";
+
 export function extractImageFromClipboardEvent(event: ClipboardEvent): File | null {
   const items = event.clipboardData?.items;
   if (!items) return null;
@@ -30,7 +32,22 @@ export function isEditablePasteTarget(target: EventTarget | null): boolean {
 
   if (element.isContentEditable) return true;
 
-  return Boolean(element.closest?.("[contenteditable='true']"));
+  return Boolean(
+    element.closest?.("[contenteditable]") ||
+      element.closest?.("[contenteditable='true']") ||
+      element.closest?.("[contenteditable='plaintext-only']")
+  );
+}
+
+export function getClipboardImageExtension(mimeType: string | undefined): string {
+  const subtype = mimeType?.trim().toLowerCase().match(/^image\/([^;]+)/)?.[1];
+  if (!subtype) return "png";
+
+  return subtype.split("+")[0].replace(/[^a-z0-9]/g, "") || "png";
+}
+
+export function getPastedImageError(file: File, maxSizeBytes: number): string | null {
+  return file.size > maxSizeBytes ? PASTED_IMAGE_SIZE_ERROR : null;
 }
 
 export function defaultScreenshotFileName(extension = "png"): string {

--- a/app/routes/_protected.customers.$customerId.tsx
+++ b/app/routes/_protected.customers.$customerId.tsx
@@ -476,6 +476,10 @@ export async function action({ request, params }: ActionFunctionArgs) {
       // Link to customer
       await linkAttachmentToCustomer(customer.id, attachment.id, eventContext);
 
+      if (formData.get("_noRedirect")) {
+        return json({ success: true, attachmentId: attachment.id });
+      }
+
       // Return a redirect to refresh the page
       return redirect(`/customers/${customerId}`);
     } catch (error) {

--- a/app/routes/_protected.vendors.$vendorId.tsx
+++ b/app/routes/_protected.vendors.$vendorId.tsx
@@ -128,6 +128,10 @@ export async function action({ request, params }: ActionFunctionArgs) {
       // Link to vendor
       await linkAttachmentToVendor(vendor.id, attachment.id, eventContext);
 
+      if (formData.get("_noRedirect")) {
+        return json({ success: true, attachmentId: attachment.id });
+      }
+
       // Return a redirect to refresh the page
       return redirect(`/vendors/${vendorId}`);
     } catch (error) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,9 @@
       "devDependencies": {
         "@babel/traverse": "^7.28.0",
         "@remix-run/dev": "^2.17.5",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/react": "^18.2.20",
         "@types/react-dom": "^18.2.7",
         "@types/sanitize-html": "^2.16.1",
@@ -61,6 +64,7 @@
         "eslint-plugin-jsx-a11y": "^6.8.0",
         "eslint-plugin-react": "^7.33.2",
         "eslint-plugin-react-hooks": "^4.6.0",
+        "happy-dom": "^20.10.4",
         "husky": "^9.1.7",
         "lint-staged": "^16.4.0",
         "postcss": "^8.5.6",
@@ -72,6 +76,13 @@
         "vite-tsconfig-paths": "^4.3.1",
         "vitest": "^4.1.5"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
+      "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -3859,6 +3870,107 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
     "node_modules/@tootallnate/quickjs-emscripten": {
       "version": "0.23.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
@@ -3900,6 +4012,14 @@
       "dependencies": {
         "@types/readdir-glob": "*"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -4153,6 +4273,13 @@
       "version": "0.5.24",
       "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.24.tgz",
       "integrity": "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/whatwg-mimetype": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/ws": {
@@ -5836,6 +5963,19 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "license": "MIT"
     },
+    "node_modules/buffer-image-size": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/buffer-image-size/-/buffer-image-size-0.6.4.tgz",
+      "integrity": "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -6733,6 +6873,13 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -7138,6 +7285,14 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dom-serializer": {
       "version": "2.0.0",
@@ -9309,6 +9464,38 @@
         "gunzip-maybe": "bin.js"
       }
     },
+    "node_modules/happy-dom": {
+      "version": "20.10.4",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.10.4.tgz",
+      "integrity": "sha512-bKrsQnFNpcjZG0UPsH7UMN7Oyp3AB42LXk2GuiQmu7l4QFxH7lsw5T1eWEtE2+vbIFrTC45sbNSB2pkB8MTfKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=20.0.0",
+        "@types/whatwg-mimetype": "^3.0.2",
+        "@types/ws": "^8.18.1",
+        "buffer-image-size": "^0.6.4",
+        "entities": "^7.0.1",
+        "whatwg-mimetype": "^3.0.0",
+        "ws": "^8.21.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/happy-dom/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/has-bigints": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
@@ -9675,6 +9862,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/inherits": {
@@ -11445,6 +11642,17 @@
         "node": ">=12"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/maath": {
       "version": "0.10.8",
       "resolved": "https://registry.npmjs.org/maath/-/maath-0.10.8.tgz",
@@ -12528,6 +12736,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/minimatch": {
@@ -14115,6 +14333,44 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/pretty-ms": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-7.0.1.tgz",
@@ -14634,6 +14890,20 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -16017,6 +16287,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-json-comments": {
@@ -17635,6 +17918,16 @@
       "resolved": "https://registry.npmjs.org/webgl-sdf-generator/-/webgl-sdf-generator-1.1.1.tgz",
       "integrity": "sha512-9Z0JcMTFxeE+b2x1LJTdnaT8rT8aEp7MVxkNwoycNmJWwPdzoXzMh0BjJSh/AEFP+KPYZUli814h8bJZFIZ2jA==",
       "license": "MIT"
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/which": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,9 @@
   "devDependencies": {
     "@babel/traverse": "^7.28.0",
     "@remix-run/dev": "^2.17.5",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/react": "^18.2.20",
     "@types/react-dom": "^18.2.7",
     "@types/sanitize-html": "^2.16.1",
@@ -91,6 +94,7 @@
     "eslint-plugin-jsx-a11y": "^6.8.0",
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^4.6.0",
+    "happy-dom": "^20.10.4",
     "husky": "^9.1.7",
     "lint-staged": "^16.4.0",
     "postcss": "^8.5.6",

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -6,6 +6,7 @@
   "include": [
     "vitest.config.ts",
     "app/**/*.test.ts",
+    "app/**/*.test.tsx",
     "app/**/*.integration.test.ts",
     "app/test/**/*.ts"
   ]

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -16,7 +16,7 @@ export default defineConfig({
     },
     // Load .env before each worker's module graph is built
     setupFiles: ["dotenv/config"],
-    include: ["app/**/*.test.ts", "app/**/*.integration.test.ts"],
+    include: ["app/**/*.test.ts", "app/**/*.test.tsx", "app/**/*.integration.test.ts"],
     exclude: ["**/node_modules/**", "**/build/**"],
     pool: "forks",
     coverage: {


### PR DESCRIPTION
## Summary
- Adds clipboard image paste handling to the shared attachment section so detail pages can preview, rename, and upload screenshots.
- Adds a reusable paste attachment modal with upload state and inline errors.
- Allows customer and vendor attachment uploads to return JSON for no-redirect fetcher uploads, matching quote and order behavior.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test`
- [x] Browser smoke test: paste screenshot on quote, order, customer, and vendor detail pages