### PR TITLE
fix(toolpath): prevent key_strict_fifo queue blockage on failed jobs

### DIFF
--- a/app/lib/queue/handlers/toolpath-stale-cleanup.test.ts
+++ b/app/lib/queue/handlers/toolpath-stale-cleanup.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Job } from "pg-boss";
+
+vi.mock("../../toolpath-upload.server", () => ({
+  failStaleToolpathQueuedParts: vi.fn(),
+  unblockFailedToolpathUploadJobs: vi.fn(),
+}));
+
+import {
+  failStaleToolpathQueuedParts,
+  unblockFailedToolpathUploadJobs,
+} from "../../toolpath-upload.server";
+import { handleToolpathStaleCleanup } from "./toolpath-stale-cleanup";
+
+describe("handleToolpathStaleCleanup", () => {
+  beforeEach(() => {
+    vi.mocked(failStaleToolpathQueuedParts).mockReset();
+    vi.mocked(unblockFailedToolpathUploadJobs).mockReset();
+  });
+
+  it("runs stale-part cleanup and failed-job unblocking", async () => {
+    vi.mocked(failStaleToolpathQueuedParts).mockResolvedValue(2);
+    vi.mocked(unblockFailedToolpathUploadJobs).mockResolvedValue(1);
+
+    await handleToolpathStaleCleanup([
+      {
+        id: "job-1",
+        name: "toolpath-stale-cleanup",
+        data: { triggeredAt: new Date().toISOString() },
+      } as Job<{ triggeredAt: string }>,
+    ]);
+
+    expect(failStaleToolpathQueuedParts).toHaveBeenCalledTimes(1);
+    expect(unblockFailedToolpathUploadJobs).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/lib/queue/handlers/toolpath-stale-cleanup.ts
+++ b/app/lib/queue/handlers/toolpath-stale-cleanup.ts
@@ -1,6 +1,9 @@
 import type { Job } from "pg-boss";
 import type { ToolpathStaleCleanupPayload } from "../types";
-import { failStaleToolpathQueuedParts } from "../../toolpath-upload.server";
+import {
+  failStaleToolpathQueuedParts,
+  unblockFailedToolpathUploadJobs,
+} from "../../toolpath-upload.server";
 
 export async function handleToolpathStaleCleanup(
   jobs: Job<ToolpathStaleCleanupPayload>[],
@@ -13,9 +16,10 @@ export async function handleToolpathStaleCleanup(
     );
 
     const failedCount = await failStaleToolpathQueuedParts();
+    const unblockedCount = await unblockFailedToolpathUploadJobs();
 
     console.log(
-      `[Worker:ToolpathStaleCleanup] Job ${job.id} completed in ${Date.now() - start}ms; failed ${failedCount} stale part(s)`,
+      `[Worker:ToolpathStaleCleanup] Job ${job.id} completed in ${Date.now() - start}ms; failed ${failedCount} stale part(s); unblocked ${unblockedCount} failed job(s)`,
     );
   }
 }

--- a/app/lib/queue/handlers/toolpath-upload.test.ts
+++ b/app/lib/queue/handlers/toolpath-upload.test.ts
@@ -3,7 +3,6 @@ import type { JobWithMetadata } from "pg-boss";
 
 const mocks = vi.hoisted(() => ({
   mockUpdate: vi.fn(),
-  mockSelect: vi.fn(),
   mockUpload: vi.fn(),
   mockIsToolpathEnabled: vi.fn(),
   mockSendPoll: vi.fn(),
@@ -14,7 +13,6 @@ const mocks = vi.hoisted(() => ({
 vi.mock("../../db", () => ({
   db: {
     update: mocks.mockUpdate,
-    select: mocks.mockSelect,
   },
 }));
 
@@ -42,15 +40,6 @@ function chainReturning(rows: unknown[]) {
     set: vi.fn().mockReturnThis(),
     where: vi.fn().mockReturnThis(),
     returning: vi.fn().mockResolvedValue(rows),
-  };
-  return chain;
-}
-
-function selectChainReturning(rows: unknown[]) {
-  const chain = {
-    from: vi.fn().mockReturnThis(),
-    where: vi.fn().mockReturnThis(),
-    limit: vi.fn().mockResolvedValue(rows),
   };
   return chain;
 }
@@ -186,7 +175,7 @@ describe("handleToolpathUpload", () => {
         partFileUrl: "quote-parts/part-1/source/file.step",
       },
     ]);
-    const failedChain = chainReturning([]);
+    const failedChain = chainReturning([{ partName: "Bracket" }]);
 
     mocks.mockUpdate
       .mockReturnValueOnce(claimChain)
@@ -214,15 +203,7 @@ describe("handleToolpathUpload", () => {
 
   it("fails fast when Toolpath API is not configured", async () => {
     mocks.mockIsToolpathEnabled.mockReturnValue(false);
-    mocks.mockSelect.mockReturnValueOnce(
-      selectChainReturning([
-        {
-          partName: "Bracket",
-          toolpathUploadStatus: "queued",
-        },
-      ]),
-    );
-    const failedChain = chainReturning([]);
+    const failedChain = chainReturning([{ partName: "Bracket" }]);
     mocks.mockUpdate.mockReturnValueOnce(failedChain);
 
     await handleToolpathUpload([

--- a/app/lib/queue/handlers/toolpath-upload.test.ts
+++ b/app/lib/queue/handlers/toolpath-upload.test.ts
@@ -3,7 +3,9 @@ import type { JobWithMetadata } from "pg-boss";
 
 const mocks = vi.hoisted(() => ({
   mockUpdate: vi.fn(),
+  mockSelect: vi.fn(),
   mockUpload: vi.fn(),
+  mockIsToolpathEnabled: vi.fn(),
   mockSendPoll: vi.fn(),
   mockCreateEvent: vi.fn(),
   mockLogAlert: vi.fn(),
@@ -12,6 +14,7 @@ const mocks = vi.hoisted(() => ({
 vi.mock("../../db", () => ({
   db: {
     update: mocks.mockUpdate,
+    select: mocks.mockSelect,
   },
 }));
 
@@ -25,6 +28,7 @@ vi.mock("../producer.server", () => ({
 
 vi.mock("../../toolpath.server", () => ({
   uploadQuotePartToToolpath: mocks.mockUpload,
+  isToolpathEnabled: mocks.mockIsToolpathEnabled,
 }));
 
 vi.mock("../../toolpath-upload.server", () => ({
@@ -38,6 +42,15 @@ function chainReturning(rows: unknown[]) {
     set: vi.fn().mockReturnThis(),
     where: vi.fn().mockReturnThis(),
     returning: vi.fn().mockResolvedValue(rows),
+  };
+  return chain;
+}
+
+function selectChainReturning(rows: unknown[]) {
+  const chain = {
+    from: vi.fn().mockReturnThis(),
+    where: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockResolvedValue(rows),
   };
   return chain;
 }
@@ -67,6 +80,7 @@ function makeJob(
 describe("handleToolpathUpload", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.mockIsToolpathEnabled.mockReturnValue(true);
     mocks.mockSendPoll.mockResolvedValue("poll-job-1");
     mocks.mockUpload.mockResolvedValue({
       toolpathPartId: "abc12345",
@@ -164,7 +178,7 @@ describe("handleToolpathUpload", () => {
     expect(mocks.mockLogAlert).not.toHaveBeenCalled();
   });
 
-  it("marks failed on the final retry attempt", async () => {
+  it("marks failed on the final retry attempt without rethrowing", async () => {
     const claimChain = chainReturning([
       {
         id: "part-1",
@@ -179,22 +193,51 @@ describe("handleToolpathUpload", () => {
       .mockReturnValueOnce(failedChain);
     mocks.mockUpload.mockRejectedValueOnce(new Error("network blip"));
 
-    await expect(
-      handleToolpathUpload([
-        makeJob(
-          {
-            quotePartId: "part-1",
-            cutConfigId: "cfg00001",
-            quoteId: 42,
-          },
-          { retryCount: 3, retryLimit: 3 },
-        ),
-      ]),
-    ).rejects.toThrow("network blip");
+    await handleToolpathUpload([
+      makeJob(
+        {
+          quotePartId: "part-1",
+          cutConfigId: "cfg00001",
+          quoteId: 42,
+        },
+        { retryCount: 3, retryLimit: 3 },
+      ),
+    ]);
 
     expect(failedChain.set).toHaveBeenCalledWith(
       expect.objectContaining({
         toolpathUploadStatus: "failed",
+      }),
+    );
+    expect(mocks.mockLogAlert).toHaveBeenCalled();
+  });
+
+  it("fails fast when Toolpath API is not configured", async () => {
+    mocks.mockIsToolpathEnabled.mockReturnValue(false);
+    mocks.mockSelect.mockReturnValueOnce(
+      selectChainReturning([
+        {
+          partName: "Bracket",
+          toolpathUploadStatus: "queued",
+        },
+      ]),
+    );
+    const failedChain = chainReturning([]);
+    mocks.mockUpdate.mockReturnValueOnce(failedChain);
+
+    await handleToolpathUpload([
+      makeJob({
+        quotePartId: "part-1",
+        cutConfigId: "cfg00001",
+        quoteId: 42,
+      }),
+    ]);
+
+    expect(mocks.mockUpload).not.toHaveBeenCalled();
+    expect(failedChain.set).toHaveBeenCalledWith(
+      expect.objectContaining({
+        toolpathUploadStatus: "failed",
+        toolpathUploadError: "Toolpath API not configured",
       }),
     );
     expect(mocks.mockLogAlert).toHaveBeenCalled();

--- a/app/lib/queue/handlers/toolpath-upload.ts
+++ b/app/lib/queue/handlers/toolpath-upload.ts
@@ -5,7 +5,10 @@ import { db } from "../../db";
 import { quoteParts } from "../../db/schema";
 import { createEvent } from "../../events";
 import { sendToolpathReportPollJob } from "../producer.server";
-import { uploadQuotePartToToolpath } from "../../toolpath.server";
+import {
+  isToolpathEnabled,
+  uploadQuotePartToToolpath,
+} from "../../toolpath.server";
 import {
   TOOLPATH_UPLOAD_STATUS,
 } from "../../toolpath-upload";
@@ -21,6 +24,33 @@ export async function handleToolpathUpload(
     console.log(
       `[Worker:ToolpathUpload] Processing quote part ${quotePartId} (job ${job.id})`,
     );
+
+    if (!isToolpathEnabled()) {
+      const [partRow] = await db
+        .select({
+          partName: quoteParts.partName,
+          toolpathUploadStatus: quoteParts.toolpathUploadStatus,
+        })
+        .from(quoteParts)
+        .where(eq(quoteParts.id, quotePartId))
+        .limit(1);
+
+      if (
+        partRow &&
+        (partRow.toolpathUploadStatus === TOOLPATH_UPLOAD_STATUS.QUEUED ||
+          partRow.toolpathUploadStatus === TOOLPATH_UPLOAD_STATUS.IN_PROGRESS)
+      ) {
+        await markToolpathUploadFailed({
+          quotePartId,
+          quoteId,
+          partName: partRow.partName,
+          error: "Toolpath API not configured",
+          jobId: job.id,
+          triggeredByUserId,
+        });
+      }
+      continue;
+    }
 
     const claimed = await db
       .update(quoteParts)
@@ -124,21 +154,22 @@ export async function handleToolpathUpload(
           jobId: job.id,
           triggeredByUserId,
         });
-      } else {
-        await db
-          .update(quoteParts)
-          .set({
-            toolpathUploadStatus: TOOLPATH_UPLOAD_STATUS.QUEUED,
-            toolpathUploadError: message,
-            updatedAt: new Date(),
-          })
-          .where(
-            and(
-              eq(quoteParts.id, quotePartId),
-              eq(quoteParts.toolpathUploadJobId, job.id),
-            ),
-          );
+        continue;
       }
+
+      await db
+        .update(quoteParts)
+        .set({
+          toolpathUploadStatus: TOOLPATH_UPLOAD_STATUS.QUEUED,
+          toolpathUploadError: message,
+          updatedAt: new Date(),
+        })
+        .where(
+          and(
+            eq(quoteParts.id, quotePartId),
+            eq(quoteParts.toolpathUploadJobId, job.id),
+          ),
+        );
 
       throw error;
     }

--- a/app/lib/queue/handlers/toolpath-upload.ts
+++ b/app/lib/queue/handlers/toolpath-upload.ts
@@ -26,29 +26,14 @@ export async function handleToolpathUpload(
     );
 
     if (!isToolpathEnabled()) {
-      const [partRow] = await db
-        .select({
-          partName: quoteParts.partName,
-          toolpathUploadStatus: quoteParts.toolpathUploadStatus,
-        })
-        .from(quoteParts)
-        .where(eq(quoteParts.id, quotePartId))
-        .limit(1);
-
-      if (
-        partRow &&
-        (partRow.toolpathUploadStatus === TOOLPATH_UPLOAD_STATUS.QUEUED ||
-          partRow.toolpathUploadStatus === TOOLPATH_UPLOAD_STATUS.IN_PROGRESS)
-      ) {
-        await markToolpathUploadFailed({
-          quotePartId,
-          quoteId,
-          partName: partRow.partName,
-          error: "Toolpath API not configured",
-          jobId: job.id,
-          triggeredByUserId,
-        });
-      }
+      await markToolpathUploadFailed({
+        quotePartId,
+        quoteId,
+        error: "Toolpath API not configured",
+        jobId: job.id,
+        triggeredByUserId,
+        onlyIfInFlight: true,
+      });
       continue;
     }
 
@@ -179,19 +164,27 @@ export async function handleToolpathUpload(
 async function markToolpathUploadFailed(opts: {
   quotePartId: string;
   quoteId: number;
-  partName: string;
+  partName?: string;
   error: string;
   jobId: string;
   triggeredByUserId?: string;
-}): Promise<void> {
-  logToolpathUploadAlert("Toolpath upload failed", {
-    quotePartId: opts.quotePartId,
-    quoteId: opts.quoteId,
-    jobId: opts.jobId,
-    error: opts.error,
-  });
+  onlyIfInFlight?: boolean;
+}): Promise<boolean> {
+  const whereConditions = [eq(quoteParts.id, opts.quotePartId)];
+  if (opts.onlyIfInFlight) {
+    const inFlightCondition = or(
+      eq(quoteParts.toolpathUploadStatus, TOOLPATH_UPLOAD_STATUS.QUEUED),
+      eq(
+        quoteParts.toolpathUploadStatus,
+        TOOLPATH_UPLOAD_STATUS.IN_PROGRESS,
+      ),
+    );
+    if (inFlightCondition) {
+      whereConditions.push(inFlightCondition);
+    }
+  }
 
-  await db
+  const [updated] = await db
     .update(quoteParts)
     .set({
       toolpathUploadStatus: TOOLPATH_UPLOAD_STATUS.FAILED,
@@ -199,7 +192,21 @@ async function markToolpathUploadFailed(opts: {
       toolpathQueuedAt: null,
       updatedAt: new Date(),
     })
-    .where(eq(quoteParts.id, opts.quotePartId));
+    .where(and(...whereConditions))
+    .returning({ partName: quoteParts.partName });
+
+  if (!updated) {
+    return false;
+  }
+
+  const partName = opts.partName ?? updated.partName;
+
+  logToolpathUploadAlert("Toolpath upload failed", {
+    quotePartId: opts.quotePartId,
+    quoteId: opts.quoteId,
+    jobId: opts.jobId,
+    error: opts.error,
+  });
 
   try {
     await createEvent({
@@ -208,11 +215,11 @@ async function markToolpathUploadFailed(opts: {
       eventType: "toolpath_upload",
       eventCategory: "manufacturing",
       title: "Toolpath upload failed",
-      description: `Failed to upload ${opts.partName} to Toolpath: ${opts.error}`,
+      description: `Failed to upload ${partName} to Toolpath: ${opts.error}`,
       metadata: {
         quoteId: opts.quoteId,
         quotePartId: opts.quotePartId,
-        partName: opts.partName,
+        partName,
         success: false,
         error: opts.error,
         jobId: opts.jobId,
@@ -222,4 +229,6 @@ async function markToolpathUploadFailed(opts: {
   } catch (eventError) {
     console.error("Failed to log Toolpath upload failure event:", eventError);
   }
+
+  return true;
 }

--- a/app/lib/toolpath-upload.server.test.ts
+++ b/app/lib/toolpath-upload.server.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  mockExecute: vi.fn(),
+  mockUpdate: vi.fn(),
+}));
+
+vi.mock("./db", () => ({
+  db: {
+    execute: mocks.mockExecute,
+    update: mocks.mockUpdate,
+    select: vi.fn(),
+  },
+}));
+
+import { TOOLPATH_FAILED_JOB_UNBLOCK_ERROR } from "./toolpath-upload";
+import { unblockFailedToolpathUploadJobs } from "./toolpath-upload.server";
+
+function chainReturning(rows: unknown[]) {
+  return {
+    set: vi.fn().mockReturnThis(),
+    where: vi.fn().mockReturnThis(),
+    returning: vi.fn().mockResolvedValue(rows),
+  };
+}
+
+describe("unblockFailedToolpathUploadJobs", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.mockUpdate.mockReturnValue(chainReturning([]));
+  });
+
+  it("reconciles stuck parts and deletes failed pg-boss jobs", async () => {
+    mocks.mockExecute
+      .mockResolvedValueOnce([
+        {
+          id: "job-failed-1",
+          data: {
+            quotePartId: "part-1",
+            quoteId: 42,
+            cutConfigId: "cfg00001",
+          },
+          output: {
+            message: "Toolpath API not configured",
+          },
+        },
+      ])
+      .mockResolvedValueOnce([]);
+
+    const count = await unblockFailedToolpathUploadJobs();
+
+    expect(count).toBe(1);
+    expect(mocks.mockUpdate).toHaveBeenCalledTimes(1);
+    expect(mocks.mockExecute).toHaveBeenCalledTimes(2);
+  });
+
+  it("uses default error message when job output is missing", async () => {
+    mocks.mockExecute
+      .mockResolvedValueOnce([
+        {
+          id: "job-failed-2",
+          data: {
+            quotePartId: "part-2",
+            quoteId: 7,
+          },
+          output: null,
+        },
+      ])
+      .mockResolvedValueOnce([]);
+
+    await unblockFailedToolpathUploadJobs();
+
+    const updateChain = mocks.mockUpdate.mock.results[0]?.value;
+    expect(updateChain.set).toHaveBeenCalledWith(
+      expect.objectContaining({
+        toolpathUploadError: TOOLPATH_FAILED_JOB_UNBLOCK_ERROR,
+      }),
+    );
+  });
+
+  it("returns zero when no failed jobs block the queue", async () => {
+    mocks.mockExecute.mockResolvedValueOnce([]);
+
+    const count = await unblockFailedToolpathUploadJobs();
+
+    expect(count).toBe(0);
+    expect(mocks.mockUpdate).not.toHaveBeenCalled();
+    expect(mocks.mockExecute).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/lib/toolpath-upload.server.ts
+++ b/app/lib/toolpath-upload.server.ts
@@ -1,7 +1,10 @@
-import { and, eq, inArray, lt, sql } from "drizzle-orm";
+import { and, eq, inArray, lt, or, sql } from "drizzle-orm";
 import { db } from "./db";
 import { quoteParts } from "./db/schema";
+import { QUEUES } from "./queue/types";
 import {
+  TOOLPATH_FAILED_JOB_UNBLOCK_ERROR,
+  TOOLPATH_PART_CREATION_SINGLETON_KEY,
   TOOLPATH_REPORT_TIMEOUT_ERROR,
   TOOLPATH_STALE_QUEUED_ERROR,
   TOOLPATH_STALE_QUEUED_MS,
@@ -80,6 +83,109 @@ export async function failStaleToolpathQueuedParts(
   }
 
   return staleParts.length;
+}
+
+interface FailedToolpathUploadJobRow {
+  id: string;
+  quotePartId: string | null;
+  quoteId: number | null;
+  errorMessage: string | null;
+}
+
+function parseFailedToolpathUploadJob(row: {
+  id: string;
+  data: unknown;
+  output: unknown;
+}): FailedToolpathUploadJobRow {
+  const data =
+    typeof row.data === "object" && row.data !== null
+      ? (row.data as Record<string, unknown>)
+      : {};
+  const output =
+    typeof row.output === "object" && row.output !== null
+      ? (row.output as Record<string, unknown>)
+      : null;
+
+  const quotePartId =
+    typeof data.quotePartId === "string" ? data.quotePartId : null;
+  const quoteId = typeof data.quoteId === "number" ? data.quoteId : null;
+  const errorMessage =
+    typeof output?.message === "string"
+      ? output.message
+      : TOOLPATH_FAILED_JOB_UNBLOCK_ERROR;
+
+  return {
+    id: row.id,
+    quotePartId,
+    quoteId,
+    errorMessage,
+  };
+}
+
+export async function unblockFailedToolpathUploadJobs(): Promise<number> {
+  const result = await db.execute(sql`
+    SELECT id, data, output
+    FROM pgboss.job
+    WHERE name = ${QUEUES.TOOLPATH_UPLOAD}
+      AND state = 'failed'
+      AND singleton_key = ${TOOLPATH_PART_CREATION_SINGLETON_KEY}
+  `);
+
+  const failedJobs = (
+    result as unknown as Array<{
+      id: string;
+      data: unknown;
+      output: unknown;
+    }>
+  ).map((row) =>
+    parseFailedToolpathUploadJob({
+      id: String(row.id),
+      data: row.data,
+      output: row.output,
+    }),
+  );
+
+  for (const failedJob of failedJobs) {
+    if (failedJob.quotePartId) {
+      await db
+        .update(quoteParts)
+        .set({
+          toolpathUploadStatus: TOOLPATH_UPLOAD_STATUS.FAILED,
+          toolpathUploadError: failedJob.errorMessage,
+          toolpathQueuedAt: null,
+          updatedAt: new Date(),
+        })
+        .where(
+          and(
+            eq(quoteParts.id, failedJob.quotePartId),
+            or(
+              eq(
+                quoteParts.toolpathUploadStatus,
+                TOOLPATH_UPLOAD_STATUS.QUEUED,
+              ),
+              eq(
+                quoteParts.toolpathUploadStatus,
+                TOOLPATH_UPLOAD_STATUS.IN_PROGRESS,
+              ),
+            ),
+          ),
+        );
+    }
+
+    await db.execute(sql`
+      DELETE FROM pgboss.job
+      WHERE id = ${failedJob.id}
+    `);
+
+    logToolpathUploadAlert("Removed failed Toolpath upload job blocking queue", {
+      jobId: failedJob.id,
+      quotePartId: failedJob.quotePartId,
+      quoteId: failedJob.quoteId,
+      error: failedJob.errorMessage,
+    });
+  }
+
+  return failedJobs.length;
 }
 
 export { TOOLPATH_REPORT_TIMEOUT_ERROR };

--- a/app/lib/toolpath-upload.ts
+++ b/app/lib/toolpath-upload.ts
@@ -25,6 +25,9 @@ export const TOOLPATH_REPORT_POLL_MAX_MS = 10 * 60 * 1000;
 export const TOOLPATH_STALE_QUEUED_ERROR =
   "Upload never started — worker may not be running";
 
+export const TOOLPATH_FAILED_JOB_UNBLOCK_ERROR =
+  "Upload job failed permanently — automatic queue recovery applied";
+
 export const TOOLPATH_REPORT_TIMEOUT_ERROR =
   "Toolpath report not ready after 10 minutes";
 


### PR DESCRIPTION
### **User description**
## Summary
- Complete `toolpath-upload` jobs on final failure instead of rethrowing, so `key_strict_fifo` is not permanently blocked by a failed pg-boss row
- Fail fast when `TOOLPATH_API_KEY` is missing instead of retrying and holding the queue
- Extend `toolpath-stale-cleanup` to reconcile stuck quote parts and delete failed upload jobs that block the shared singleton key (covers worker crash / job expiration paths)

## Test plan
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `vitest` for toolpath upload handler, stale cleanup handler, and upload server cleanup helper
- [ ] CI checks green on this PR
- [ ] Post-merge: confirm staging worker restart policy and that a failed upload no longer blocks subsequent uploads


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Prevent Toolpath queue blockage

- Complete final upload failures

- Fail fast when unconfigured

- Add recovery cleanup tests


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Toolpath upload job"] -- "API missing or final failure" --> B["Mark quote part failed"]
  B -- "do not rethrow final failure" --> C["pg-boss queue advances"]
  D["Stale cleanup"] -- "find failed singleton jobs" --> E["Reconcile stuck parts"]
  E -- "delete blocking jobs" --> C
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>toolpath-stale-cleanup.test.ts</strong><dd><code>Add stale cleanup unblocking handler test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SubtractManufacturing/Subtract-Admin-Dashboard/pull/145/files#diff-561ce4a0a151b083c465a859066e797378805aa4012a1e8c56da38e053861188">+36/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>toolpath-upload.test.ts</strong><dd><code>Cover final failure and config handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SubtractManufacturing/Subtract-Admin-Dashboard/pull/145/files#diff-505d07026efe3a0d49404ff8b573d1819881a72f0aeb076fccaab849b0664cf3">+38/-14</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>toolpath-upload.server.test.ts</strong><dd><code>Test failed job queue recovery helper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SubtractManufacturing/Subtract-Admin-Dashboard/pull/145/files#diff-57ff1ade8ca14c04168fe5e84fd7f4d3f366c80f37104b4b92ca3639399178f1">+90/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>toolpath-stale-cleanup.ts</strong><dd><code>Unblock failed upload jobs during cleanup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SubtractManufacturing/Subtract-Admin-Dashboard/pull/145/files#diff-b7fb7e73db92fc07c70a5b62854506fab57102fbeb70551f53f0127c11a0a263">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>toolpath-upload.ts</strong><dd><code>Avoid blocking queue on upload failures</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SubtractManufacturing/Subtract-Admin-Dashboard/pull/145/files#diff-7dea1df6b36a1c4ad4874f08c0190d152cd8dde05d3e9af571bac439a16e4f62">+67/-27</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>toolpath-upload.server.ts</strong><dd><code>Add failed Toolpath job unblocking helper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SubtractManufacturing/Subtract-Admin-Dashboard/pull/145/files#diff-be59d7fa342a33f86875a80808d9eccb2bb0dfb1e0fa8e6029bff111d57d8673">+107/-1</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>toolpath-upload.ts</strong><dd><code>Add failed job recovery error constant</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SubtractManufacturing/Subtract-Admin-Dashboard/pull/145/files#diff-f6a5ee6c6293d6266bb5c4e5e093adc1475e9bbb29514dad11e4c666407e1552">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved toolpath upload handling when the service isn’t configured—jobs now fail cleanly with a clear “permanently failed” message instead of repeatedly retrying.
  * Final retry failures now stop processing immediately and are recorded more consistently.
  * Enhanced stale cleanup to automatically recover stuck/failed toolpath upload jobs, clear their queued timestamps, update upload failure reasons, and log both recovered and failed counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->