### PR TITLE
Add CRM-lite functionality

### DIFF
--- a/app/components/Sidebar.tsx
+++ b/app/components/Sidebar.tsx
@@ -1,5 +1,6 @@
 import { Link, useLocation, useFetcher } from "@remix-run/react";
 import { useState, useRef, useEffect } from "react";
+import { BookUser } from "lucide-react";
 import { useTheme } from "~/contexts/ThemeContext";
 import { useSidebar } from "~/contexts/SidebarContext";
 
@@ -152,6 +153,11 @@ export default function Sidebar({
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
         </svg>
       ),
+    },
+    {
+      to: "/crm",
+      label: "CRM",
+      icon: <BookUser className="w-5 h-5" />,
     },
   ];
 

--- a/app/components/crm/LogCommunicationModal.tsx
+++ b/app/components/crm/LogCommunicationModal.tsx
@@ -1,0 +1,141 @@
+import { useFetcher } from "@remix-run/react";
+import { useEffect, useState } from "react";
+import Modal from "~/components/shared/Modal";
+import Button from "~/components/shared/Button";
+import SearchableSelect from "~/components/shared/SearchableSelect";
+import {
+  COMMUNICATION_METHODS,
+  COMMUNICATION_METHOD_LABELS,
+  type CommunicationMethod,
+} from "~/lib/crm-constants";
+
+type CustomerOption = {
+  id: number;
+  displayName: string;
+  email?: string | null;
+};
+
+type Props = {
+  isOpen: boolean;
+  onClose: () => void;
+  customers: CustomerOption[];
+  defaultCustomerId?: number | null;
+};
+
+export default function LogCommunicationModal({
+  isOpen,
+  onClose,
+  customers,
+  defaultCustomerId = null,
+}: Props) {
+  const fetcher = useFetcher<{ error?: string; success?: boolean }>();
+  const [customerId, setCustomerId] = useState(
+    defaultCustomerId ? String(defaultCustomerId) : "",
+  );
+  const [method, setMethod] = useState<CommunicationMethod | "">("");
+  const [note, setNote] = useState("");
+
+  useEffect(() => {
+    if (isOpen) {
+      setCustomerId(defaultCustomerId ? String(defaultCustomerId) : "");
+      setMethod("");
+      setNote("");
+    }
+  }, [isOpen, defaultCustomerId]);
+
+  useEffect(() => {
+    if (fetcher.data?.success) {
+      onClose();
+    }
+  }, [fetcher.data, onClose]);
+
+  const isSubmitting = fetcher.state !== "idle";
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      title="Log Communication"
+      size="md"
+    >
+      <fetcher.Form method="post" action="/crm" className="space-y-4">
+        <input type="hidden" name="intent" value="create" />
+        <input type="hidden" name="customerId" value={customerId} />
+
+        <SearchableSelect
+          label="Customer"
+          value={customerId}
+          onChange={setCustomerId}
+          options={customers.map((customer) => ({
+            value: customer.id.toString(),
+            label: customer.displayName,
+            secondaryLabel: customer.email || undefined,
+          }))}
+          placeholder="Search for a customer..."
+          required
+          emptyMessage="No customers found"
+        />
+
+        <div>
+          <label
+            htmlFor="crm-method"
+            className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
+          >
+            Method
+          </label>
+          <select
+            id="crm-method"
+            name="method"
+            required
+            value={method}
+            onChange={(e) =>
+              setMethod(e.target.value as CommunicationMethod | "")
+            }
+            className="w-full h-10 px-3 border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 rounded focus:outline-none focus:ring-2 focus:ring-blue-500"
+          >
+            <option value="">Select a method…</option>
+            {COMMUNICATION_METHODS.map((m) => (
+              <option key={m} value={m}>
+                {COMMUNICATION_METHOD_LABELS[m]}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div>
+          <label
+            htmlFor="crm-note"
+            className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
+          >
+            Note
+          </label>
+          <textarea
+            id="crm-note"
+            name="note"
+            required
+            rows={4}
+            value={note}
+            onChange={(e) => setNote(e.target.value)}
+            className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 rounded focus:outline-none focus:ring-2 focus:ring-blue-500"
+            placeholder="What was discussed…"
+          />
+        </div>
+
+        {fetcher.data?.error && (
+          <p className="text-sm text-red-600 dark:text-red-400">
+            {fetcher.data.error}
+          </p>
+        )}
+
+        <div className="flex justify-end gap-2 pt-2">
+          <Button type="button" variant="secondary" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button type="submit" disabled={isSubmitting || !customerId}>
+            {isSubmitting ? "Saving…" : "Save"}
+          </Button>
+        </div>
+      </fetcher.Form>
+    </Modal>
+  );
+}

--- a/app/lib/crm-constants.ts
+++ b/app/lib/crm-constants.ts
@@ -1,0 +1,24 @@
+export const CRM_PAGE_SIZE = 25;
+
+export const COMMUNICATION_METHODS = [
+  "call",
+  "text",
+  "email",
+  "social_media_dm",
+] as const;
+
+export type CommunicationMethod = (typeof COMMUNICATION_METHODS)[number];
+
+export const COMMUNICATION_METHOD_LABELS: Record<CommunicationMethod, string> =
+  {
+    call: "Call",
+    text: "Text",
+    email: "Email",
+    social_media_dm: "Social media DM",
+  };
+
+export function isCommunicationMethod(
+  value: string,
+): value is CommunicationMethod {
+  return (COMMUNICATION_METHODS as readonly string[]).includes(value);
+}

--- a/app/lib/crm.ts
+++ b/app/lib/crm.ts
@@ -126,26 +126,31 @@ export async function createCustomerCommunication(
     createdBy: data.createdBy,
   };
 
-  const [created] = await db
-    .insert(customerCommunications)
-    .values(insertValues)
-    .returning();
+  return await db.transaction(async (tx) => {
+    const [created] = await tx
+      .insert(customerCommunications)
+      .values(insertValues)
+      .returning();
 
-  await createEvent({
-    entityType: "customer",
-    entityId: String(data.customerId),
-    eventType: "crm_communication_logged",
-    eventCategory: "communication",
-    title: "Communication logged",
-    description: `${COMMUNICATION_METHOD_LABELS[data.method]} with ${customer.displayName}`,
-    metadata: {
-      communicationId: created.id,
-      method: data.method,
-      notePreview: note.substring(0, 100),
-    },
-    userId: eventContext?.userId,
-    userEmail: eventContext?.userEmail,
+    await createEvent(
+      {
+        entityType: "customer",
+        entityId: String(data.customerId),
+        eventType: "crm_communication_logged",
+        eventCategory: "communication",
+        title: "Communication logged",
+        description: `${COMMUNICATION_METHOD_LABELS[data.method]} with ${customer.displayName}`,
+        metadata: {
+          communicationId: created.id,
+          method: data.method,
+          notePreview: note.substring(0, 100),
+        },
+        userId: eventContext?.userId,
+        userEmail: eventContext?.userEmail,
+      },
+      tx,
+    );
+
+    return created;
   });
-
-  return created;
 }

--- a/app/lib/crm.ts
+++ b/app/lib/crm.ts
@@ -1,0 +1,151 @@
+import { and, count, desc, eq } from "drizzle-orm";
+import { db } from "./db";
+import {
+  customerCommunications,
+  customers,
+  users,
+  type CustomerCommunication,
+  type NewCustomerCommunication,
+} from "./db/schema";
+import { createEvent } from "./events";
+import {
+  COMMUNICATION_METHOD_LABELS,
+  COMMUNICATION_METHODS,
+  CRM_PAGE_SIZE,
+  type CommunicationMethod,
+} from "./crm-constants";
+
+export {
+  COMMUNICATION_METHOD_LABELS,
+  COMMUNICATION_METHODS,
+  CRM_PAGE_SIZE,
+  isCommunicationMethod,
+  type CommunicationMethod,
+} from "./crm-constants";
+
+export type CrmEventContext = {
+  userId?: string;
+  userEmail?: string;
+};
+
+export type CustomerCommunicationListItem = CustomerCommunication & {
+  customerDisplayName: string;
+  authorName: string | null;
+  authorEmail: string | null;
+};
+
+export type ListCommunicationsParams = {
+  customerId?: number;
+  page?: number; // 1-based
+  pageSize?: number;
+};
+
+export async function listCustomerCommunications(
+  params: ListCommunicationsParams = {},
+): Promise<{
+  items: CustomerCommunicationListItem[];
+  totalCount: number;
+  page: number;
+  pageSize: number;
+  totalPages: number;
+}> {
+  const pageSize = params.pageSize ?? CRM_PAGE_SIZE;
+  const conditions = [eq(customerCommunications.isArchived, false)];
+  if (params.customerId != null) {
+    conditions.push(eq(customerCommunications.customerId, params.customerId));
+  }
+  const where = and(...conditions);
+
+  const [countRow] = await db
+    .select({ count: count() })
+    .from(customerCommunications)
+    .where(where);
+
+  const totalCount = Number(countRow?.count ?? 0);
+  const totalPages = Math.max(1, Math.ceil(totalCount / pageSize));
+  const page = Math.min(Math.max(params.page ?? 1, 1), totalPages);
+  const offset = (page - 1) * pageSize;
+
+  const rows = await db
+    .select({
+      id: customerCommunications.id,
+      customerId: customerCommunications.customerId,
+      method: customerCommunications.method,
+      note: customerCommunications.note,
+      createdBy: customerCommunications.createdBy,
+      createdAt: customerCommunications.createdAt,
+      isArchived: customerCommunications.isArchived,
+      customerDisplayName: customers.displayName,
+      authorName: users.name,
+      authorEmail: users.email,
+    })
+    .from(customerCommunications)
+    .innerJoin(customers, eq(customerCommunications.customerId, customers.id))
+    .leftJoin(users, eq(customerCommunications.createdBy, users.id))
+    .where(where)
+    .orderBy(desc(customerCommunications.createdAt))
+    .limit(pageSize)
+    .offset(offset);
+
+  return { items: rows, totalCount, page, pageSize, totalPages };
+}
+
+export async function createCustomerCommunication(
+  data: {
+    customerId: number;
+    method: CommunicationMethod;
+    note: string;
+    createdBy: string;
+  },
+  eventContext?: CrmEventContext,
+): Promise<CustomerCommunication> {
+  const note = data.note.trim();
+  if (!note) {
+    throw new Error("Note is required");
+  }
+  if (!COMMUNICATION_METHODS.includes(data.method)) {
+    throw new Error("Invalid communication method");
+  }
+
+  const [customer] = await db
+    .select({ id: customers.id, displayName: customers.displayName })
+    .from(customers)
+    .where(
+      and(eq(customers.id, data.customerId), eq(customers.isArchived, false)),
+    )
+    .limit(1);
+
+  if (!customer) {
+    throw new Error("Customer not found");
+  }
+
+  const insertValues: NewCustomerCommunication = {
+    customerId: data.customerId,
+    method: data.method,
+    note,
+    createdBy: data.createdBy,
+  };
+
+  const [created] = await db
+    .insert(customerCommunications)
+    .values(insertValues)
+    .returning();
+
+  await createEvent({
+    entityType: "customer",
+    entityId: String(data.customerId),
+    eventType: "crm_communication_logged",
+    eventCategory: "communication",
+    title: "Communication logged",
+    description: `${COMMUNICATION_METHOD_LABELS[data.method]} with ${customer.displayName}`,
+    metadata: {
+      communicationId: created.id,
+      method: data.method,
+      notePreview: note.substring(0, 100),
+    },
+    userId: eventContext?.userId,
+    userEmail: eventContext?.userEmail,
+  });
+
+  return created;
+}

--- a/app/lib/db/schema.ts
+++ b/app/lib/db/schema.ts
@@ -87,6 +87,13 @@ export const attachmentDocumentKindEnum = pgEnum("attachment_document_kind", [
   "packing_slip",
 ]);
 
+export const communicationMethodEnum = pgEnum("communication_method", [
+  "call",
+  "text",
+  "email",
+  "social_media_dm",
+]);
+
 export const users = pgTable("users", {
   id: text("id").primaryKey(), // Will match Supabase auth.users.id
   name: text("name"),
@@ -541,6 +548,33 @@ export const notes = pgTable("notes", {
   isArchived: boolean("is_archived").default(false).notNull(),
 });
 
+export const customerCommunications = pgTable(
+  "customer_communications",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    customerId: integer("customer_id")
+      .notNull()
+      .references(() => customers.id),
+    method: communicationMethodEnum("method").notNull(),
+    note: text("note").notNull(),
+    createdBy: text("created_by")
+      .notNull()
+      .references(() => users.id),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+    // No updatedAt in v1 — log entries are append-only.
+    // Soft-archive reserved for a later admin cleanup if needed:
+    isArchived: boolean("is_archived").default(false).notNull(),
+  },
+  (table) => ({
+    customerIdx: index("customer_communications_customer_idx").on(
+      table.customerId,
+    ),
+    createdAtIdx: index("customer_communications_created_at_idx").on(
+      table.createdAt,
+    ),
+  }),
+);
+
 export const featureFlags = pgTable("feature_flags", {
   id: serial("id").primaryKey(),
   key: text("key").notNull().unique(),
@@ -692,6 +726,9 @@ export type LoginAuditLog = typeof loginAuditLogs.$inferSelect;
 export type NewLoginAuditLog = typeof loginAuditLogs.$inferInsert;
 export type Note = typeof notes.$inferSelect;
 export type NewNote = typeof notes.$inferInsert;
+export type CustomerCommunication = typeof customerCommunications.$inferSelect;
+export type NewCustomerCommunication =
+  typeof customerCommunications.$inferInsert;
 export type FeatureFlag = typeof featureFlags.$inferSelect;
 export type NewFeatureFlag = typeof featureFlags.$inferInsert;
 export type EventLog = typeof eventLogs.$inferSelect;

--- a/app/lib/events.ts
+++ b/app/lib/events.ts
@@ -31,12 +31,16 @@ export interface EventFilters {
   dismissedOnly?: boolean;
 }
 
-export async function createEvent(eventData: EventLogInput): Promise<EventLog> {
+export async function createEvent(
+  eventData: EventLogInput,
+  tx?: Parameters<Parameters<typeof db.transaction>[0]>[0],
+): Promise<EventLog> {
   const newEvent: NewEventLog = {
     ...eventData,
   };
 
-  const [event] = await db.insert(eventLogs).values(newEvent).returning();
+  const queryClient = tx || db;
+  const [event] = await queryClient.insert(eventLogs).values(newEvent).returning();
   return event;
 }
 

--- a/app/lib/url-validator.ts
+++ b/app/lib/url-validator.ts
@@ -83,6 +83,7 @@ export const ALLOWED_AUTH_REDIRECTS = [
   "/",
   "/dashboard",
   "/customers",
+  "/crm",
   "/vendors",
   "/orders",
   "/ActionItems",

--- a/app/routes/_protected.crm._index.tsx
+++ b/app/routes/_protected.crm._index.tsx
@@ -120,7 +120,7 @@ export async function action({ request }: ActionFunctionArgs) {
 
   const eventContext: CrmEventContext = {
     userId: user.id,
-    userEmail: user.email || userDetails?.name || undefined,
+    userEmail: user.email || userDetails?.email || undefined,
   };
 
   try {

--- a/app/routes/_protected.crm._index.tsx
+++ b/app/routes/_protected.crm._index.tsx
@@ -1,0 +1,339 @@
+import { json } from "@remix-run/node";
+import {
+  Link,
+  useLoaderData,
+  useLocation,
+  useNavigate,
+  useSearchParams,
+} from "@remix-run/react";
+import { useState } from "react";
+import type { ActionFunctionArgs, LoaderFunctionArgs } from "@remix-run/node";
+
+import { requireAuth, withAuthHeaders } from "~/lib/auth.server";
+import { getCustomers } from "~/lib/customers";
+import {
+  createCustomerCommunication,
+  listCustomerCommunications,
+  type CrmEventContext,
+  type CustomerCommunicationListItem,
+} from "~/lib/crm";
+import {
+  COMMUNICATION_METHOD_LABELS,
+  isCommunicationMethod,
+  type CommunicationMethod,
+} from "~/lib/crm-constants";
+
+type CustomerOption = {
+  id: number;
+  displayName: string;
+  email?: string | null;
+};
+
+import SearchHeader from "~/components/SearchHeader";
+import Button from "~/components/shared/Button";
+import SearchableSelect from "~/components/shared/SearchableSelect";
+import LogCommunicationModal from "~/components/crm/LogCommunicationModal";
+
+function crmListPageHref(pathname: string, search: string, page: number) {
+  const params = new URLSearchParams(search);
+  if (page <= 1) {
+    params.delete("page");
+  } else {
+    params.set("page", String(page));
+  }
+  const qs = params.toString();
+  return qs ? `${pathname}?${qs}` : pathname;
+}
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  const { user, userDetails, headers } = await requireAuth(request);
+  const url = new URL(request.url);
+
+  const pageParam = Math.max(
+    1,
+    parseInt(url.searchParams.get("page") ?? "1", 10) || 1,
+  );
+
+  const customerIdRaw = url.searchParams.get("customerId");
+  const customerId =
+    customerIdRaw && /^\d+$/.test(customerIdRaw)
+      ? parseInt(customerIdRaw, 10)
+      : undefined;
+
+  const [listResult, customers] = await Promise.all([
+    listCustomerCommunications({
+      page: pageParam,
+      customerId,
+    }),
+    getCustomers({ sortBy: "name" }),
+  ]);
+
+  return withAuthHeaders(
+    json({
+      ...listResult,
+      customers: customers.map((c) => ({
+        id: c.id,
+        displayName: c.displayName,
+        email: c.email,
+      })),
+      filterCustomerId: customerId ?? null,
+      user,
+      userDetails,
+    }),
+    headers,
+  );
+}
+
+export async function action({ request }: ActionFunctionArgs) {
+  const { user, userDetails } = await requireAuth(request);
+  const formData = await request.formData();
+  const intent = formData.get("intent");
+
+  if (intent !== "create") {
+    return json({ error: "Invalid intent" }, { status: 400 });
+  }
+
+  if (!user?.id) {
+    return json({ error: "User not authenticated" }, { status: 401 });
+  }
+
+  const customerIdRaw = formData.get("customerId");
+  const methodRaw = formData.get("method");
+  const noteRaw = formData.get("note");
+
+  const customerId =
+    typeof customerIdRaw === "string" && /^\d+$/.test(customerIdRaw)
+      ? parseInt(customerIdRaw, 10)
+      : NaN;
+  const method = typeof methodRaw === "string" ? methodRaw : "";
+  const note = typeof noteRaw === "string" ? noteRaw : "";
+
+  if (!Number.isFinite(customerId)) {
+    return json({ error: "Customer is required" }, { status: 400 });
+  }
+  if (!isCommunicationMethod(method)) {
+    return json({ error: "Invalid communication method" }, { status: 400 });
+  }
+  if (!note.trim()) {
+    return json({ error: "Note is required" }, { status: 400 });
+  }
+
+  const eventContext: CrmEventContext = {
+    userId: user.id,
+    userEmail: user.email || userDetails?.name || undefined,
+  };
+
+  try {
+    await createCustomerCommunication(
+      {
+        customerId,
+        method,
+        note,
+        createdBy: user.id,
+      },
+      eventContext,
+    );
+    return json({ success: true });
+  } catch (error) {
+    return json({ error: (error as Error).message }, { status: 400 });
+  }
+}
+
+export default function CrmIndex() {
+  const {
+    items,
+    totalCount,
+    page,
+    totalPages,
+    customers,
+    filterCustomerId,
+  } = useLoaderData<typeof loader>();
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const location = useLocation();
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const handleFilterChange = (value: string) => {
+    const params = new URLSearchParams(searchParams);
+    params.delete("page");
+    if (value) {
+      params.set("customerId", value);
+    } else {
+      params.delete("customerId");
+    }
+    const qs = params.toString();
+    navigate(qs ? `/crm?${qs}` : "/crm");
+  };
+
+  const formatDateTime = (date: Date | string) => {
+    const dateObj = typeof date === "string" ? new Date(date) : date;
+    return dateObj.toLocaleString("en-US", {
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      hour: "numeric",
+      minute: "2-digit",
+    });
+  };
+
+  const truncateNote = (text: string, max = 120) => {
+    if (text.length <= max) return text;
+    return `${text.slice(0, max)}…`;
+  };
+
+  return (
+    <div className="max-w-[1920px] mx-auto">
+      <SearchHeader
+        breadcrumbs={[
+          { label: "Dashboard", href: "/" },
+          { label: "CRM" },
+        ]}
+      />
+
+      <div className="px-4 sm:px-6 lg:px-10 py-6 lg:py-8">
+        <div className="flex flex-wrap justify-between items-end mb-5 gap-3">
+          <h2 className="text-2xl font-semibold text-gray-900 dark:text-gray-100 transition-colors duration-150">
+            Communications ({totalCount})
+          </h2>
+          <div className="flex flex-wrap items-end gap-3">
+            <div className="min-w-[240px] w-72">
+              <SearchableSelect
+                label="Customer"
+                value={filterCustomerId ? String(filterCustomerId) : ""}
+                onChange={handleFilterChange}
+                options={[
+                  { value: "", label: "All customers" },
+                  ...customers.map((c: CustomerOption) => ({
+                    value: c.id.toString(),
+                    label: c.displayName,
+                    secondaryLabel: c.email || undefined,
+                  })),
+                ]}
+                placeholder="Search for a customer..."
+                emptyMessage="No customers found"
+              />
+            </div>
+            <Button onClick={() => setIsModalOpen(true)}>
+              Log Communication
+            </Button>
+          </div>
+        </div>
+
+        <div className="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm dark:border-slate-700 dark:bg-slate-800">
+          {items.length === 0 ? (
+            <p className="px-4 py-10 text-center text-sm text-gray-500 dark:text-gray-400">
+              {filterCustomerId
+                ? "No communications found for this customer."
+                : "No communications logged yet. Log one to get started."}
+            </p>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="min-w-full divide-y divide-gray-200 dark:divide-slate-700">
+                <thead className="bg-gray-50 dark:bg-slate-900/50">
+                  <tr>
+                    <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
+                      Date/time
+                    </th>
+                    <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
+                      Customer
+                    </th>
+                    <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
+                      Method
+                    </th>
+                    <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
+                      Note
+                    </th>
+                    <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
+                      Logged by
+                    </th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-gray-200 dark:divide-slate-700">
+                  {items.map((item: CustomerCommunicationListItem) => (
+                    <tr
+                      key={item.id}
+                      className="hover:bg-gray-50 dark:hover:bg-slate-700/40"
+                    >
+                      <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-700 dark:text-gray-300">
+                        {formatDateTime(item.createdAt)}
+                      </td>
+                      <td className="whitespace-nowrap px-4 py-3 text-sm">
+                        <Link
+                          to={`/customers/${item.customerId}`}
+                          className="font-medium text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300 hover:underline"
+                        >
+                          {item.customerDisplayName}
+                        </Link>
+                      </td>
+                      <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-700 dark:text-gray-300">
+                        {
+                          COMMUNICATION_METHOD_LABELS[
+                            item.method as CommunicationMethod
+                          ]
+                        }
+                      </td>
+                      <td
+                        className="max-w-md px-4 py-3 text-sm text-gray-700 dark:text-gray-300"
+                        title={item.note}
+                      >
+                        {truncateNote(item.note)}
+                      </td>
+                      <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-700 dark:text-gray-300">
+                        {item.authorName || item.authorEmail || "—"}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+
+          {totalPages > 1 ? (
+            <div className="flex flex-wrap items-center justify-between gap-3 border-t border-gray-200 px-4 py-3 text-sm dark:border-slate-700">
+              <Link
+                to={crmListPageHref(
+                  location.pathname,
+                  location.search,
+                  page - 1,
+                )}
+                className={
+                  page <= 1
+                    ? "pointer-events-none text-gray-300 dark:text-slate-600"
+                    : "font-medium text-blue-600 no-underline hover:underline dark:text-blue-400"
+                }
+                aria-disabled={page <= 1}
+              >
+                Previous
+              </Link>
+              <span className="text-gray-600 dark:text-gray-400">
+                Page {page} of {totalPages}
+              </span>
+              <Link
+                to={crmListPageHref(
+                  location.pathname,
+                  location.search,
+                  page + 1,
+                )}
+                className={
+                  page >= totalPages
+                    ? "pointer-events-none text-gray-300 dark:text-slate-600"
+                    : "font-medium text-blue-600 no-underline hover:underline dark:text-blue-400"
+                }
+                aria-disabled={page >= totalPages}
+              >
+                Next
+              </Link>
+            </div>
+          ) : null}
+        </div>
+      </div>
+
+      <LogCommunicationModal
+        isOpen={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+        customers={customers}
+        defaultCustomerId={filterCustomerId}
+      />
+    </div>
+  );
+}

--- a/drizzle/0019_wild_molly_hayes.sql
+++ b/drizzle/0019_wild_molly_hayes.sql
@@ -1,0 +1,15 @@
+CREATE TYPE "public"."communication_method" AS ENUM('call', 'text', 'email', 'social_media_dm');--> statement-breakpoint
+CREATE TABLE "customer_communications" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"customer_id" integer NOT NULL,
+	"method" "communication_method" NOT NULL,
+	"note" text NOT NULL,
+	"created_by" text NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"is_archived" boolean DEFAULT false NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "customer_communications" ADD CONSTRAINT "customer_communications_customer_id_customers_id_fk" FOREIGN KEY ("customer_id") REFERENCES "public"."customers"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "customer_communications" ADD CONSTRAINT "customer_communications_created_by_users_id_fk" FOREIGN KEY ("created_by") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "customer_communications_customer_idx" ON "customer_communications" USING btree ("customer_id");--> statement-breakpoint
+CREATE INDEX "customer_communications_created_at_idx" ON "customer_communications" USING btree ("created_at");

--- a/drizzle/meta/0019_snapshot.json
+++ b/drizzle/meta/0019_snapshot.json
@@ -1,0 +1,4030 @@
+{
+  "id": "9c0a9a31-b167-42db-b52c-ce26f489cbfd",
+  "prevId": "40991788-1d1a-40fc-8a84-5d535f159081",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.attachments": {
+      "name": "attachments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "s3_bucket": {
+          "name": "s3_bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail_s3_key": {
+          "name": "thumbnail_s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "attachment_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "document_kind": {
+          "name": "document_kind",
+          "type": "attachment_document_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cad_file_versions": {
+      "name": "cad_file_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_current_version": {
+          "name": "is_current_version",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_by_email": {
+          "name": "uploaded_by_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cad_versions_entity_idx": {
+          "name": "cad_versions_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cad_versions_current_idx": {
+          "name": "cad_versions_current_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_current_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cad_versions_version_idx": {
+          "name": "cad_versions_version_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cad_file_versions_uploaded_by_users_id_fk": {
+          "name": "cad_file_versions_uploaded_by_users_id_fk",
+          "tableFrom": "cad_file_versions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "uploaded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.customer_attachments": {
+      "name": "customer_attachments",
+      "schema": "",
+      "columns": {
+        "customer_id": {
+          "name": "customer_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attachment_id": {
+          "name": "attachment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "customer_attachments_customer_id_customers_id_fk": {
+          "name": "customer_attachments_customer_id_customers_id_fk",
+          "tableFrom": "customer_attachments",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "customer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "customer_attachments_attachment_id_attachments_id_fk": {
+          "name": "customer_attachments_attachment_id_attachments_id_fk",
+          "tableFrom": "customer_attachments",
+          "tableTo": "attachments",
+          "columnsFrom": [
+            "attachment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "customer_attachments_customer_id_attachment_id_pk": {
+          "name": "customer_attachments_customer_id_attachment_id_pk",
+          "columns": [
+            "customer_id",
+            "attachment_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.customer_communications": {
+      "name": "customer_communications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "communication_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "customer_communications_customer_idx": {
+          "name": "customer_communications_customer_idx",
+          "columns": [
+            {
+              "expression": "customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "customer_communications_created_at_idx": {
+          "name": "customer_communications_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "customer_communications_customer_id_customers_id_fk": {
+          "name": "customer_communications_customer_id_customers_id_fk",
+          "tableFrom": "customer_communications",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "customer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "customer_communications_created_by_users_id_fk": {
+          "name": "customer_communications_created_by_users_id_fk",
+          "tableFrom": "customer_communications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.customers": {
+      "name": "customers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_name": {
+          "name": "company_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_name": {
+          "name": "contact_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_primary_contact": {
+          "name": "is_primary_contact",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "billing_address_line1": {
+          "name": "billing_address_line1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_address_line2": {
+          "name": "billing_address_line2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_city": {
+          "name": "billing_city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_state": {
+          "name": "billing_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_postal_code": {
+          "name": "billing_postal_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_country": {
+          "name": "billing_country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'US'"
+        },
+        "shipping_address_line1": {
+          "name": "shipping_address_line1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shipping_address_line2": {
+          "name": "shipping_address_line2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shipping_city": {
+          "name": "shipping_city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shipping_state": {
+          "name": "shipping_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shipping_postal_code": {
+          "name": "shipping_postal_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shipping_country": {
+          "name": "shipping_country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'US'"
+        },
+        "payment_terms": {
+          "name": "payment_terms",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "customers_company_name_idx": {
+          "name": "customers_company_name_idx",
+          "columns": [
+            {
+              "expression": "company_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.developer_settings": {
+      "name": "developer_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "developer_settings_key_unique": {
+          "name": "developer_settings_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_identities": {
+      "name": "email_identities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "from_email": {
+          "name": "from_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_display_name": {
+          "name": "from_display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_to_email": {
+          "name": "reply_to_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_settings": {
+      "name": "email_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "email_setting_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'operational'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "email_settings_key_unique": {
+          "name": "email_settings_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_templates": {
+      "name": "email_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout_slug": {
+          "name": "layout_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'styled-quote'"
+        },
+        "context_key": {
+          "name": "context_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_identity_id": {
+          "name": "email_identity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_template": {
+          "name": "subject_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body_copy": {
+          "name": "body_copy",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "required_attachment_document_kinds": {
+          "name": "required_attachment_document_kinds",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "email_templates_email_identity_id_email_identities_id_fk": {
+          "name": "email_templates_email_identity_id_email_identities_id_fk",
+          "tableFrom": "email_templates",
+          "tableTo": "email_identities",
+          "columnsFrom": [
+            "email_identity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "email_templates_slug_unique": {
+          "name": "email_templates_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        },
+        "email_templates_context_key_unique": {
+          "name": "email_templates_context_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "context_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_logs": {
+      "name": "event_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_category": {
+          "name": "event_category",
+          "type": "event_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_email": {
+          "name": "user_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_dismissed": {
+          "name": "is_dismissed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "dismissed_at": {
+          "name": "dismissed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dismissed_by": {
+          "name": "dismissed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "event_logs_entity_idx": {
+          "name": "event_logs_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "event_logs_timestamp_idx": {
+          "name": "event_logs_timestamp_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "event_logs_category_idx": {
+          "name": "event_logs_category_idx",
+          "columns": [
+            {
+              "expression": "event_category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "event_logs_user_id_users_id_fk": {
+          "name": "event_logs_user_id_users_id_fk",
+          "tableFrom": "event_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feature_flags": {
+      "name": "feature_flags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "feature_flags_key_unique": {
+          "name": "feature_flags_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.login_audit_logs": {
+      "name": "login_audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notes": {
+      "name": "notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_attachments": {
+      "name": "order_attachments",
+      "schema": "",
+      "columns": {
+        "order_id": {
+          "name": "order_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attachment_id": {
+          "name": "attachment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "order_attachments_order_id_orders_id_fk": {
+          "name": "order_attachments_order_id_orders_id_fk",
+          "tableFrom": "order_attachments",
+          "tableTo": "orders",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "order_attachments_attachment_id_attachments_id_fk": {
+          "name": "order_attachments_attachment_id_attachments_id_fk",
+          "tableFrom": "order_attachments",
+          "tableTo": "attachments",
+          "columnsFrom": [
+            "attachment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "order_attachments_order_id_attachment_id_pk": {
+          "name": "order_attachments_order_id_attachment_id_pk",
+          "columns": [
+            "order_id",
+            "attachment_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_line_items": {
+      "name": "order_line_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "part_id": {
+          "name": "part_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hard_delete_at": {
+          "name": "hard_delete_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "order_line_items_archive_purge_idx": {
+          "name": "order_line_items_archive_purge_idx",
+          "columns": [
+            {
+              "expression": "is_archived",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hard_delete_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "order_line_items_order_id_orders_id_fk": {
+          "name": "order_line_items_order_id_orders_id_fk",
+          "tableFrom": "order_line_items",
+          "tableTo": "orders",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "order_line_items_part_id_parts_id_fk": {
+          "name": "order_line_items_part_id_parts_id_fk",
+          "tableFrom": "order_line_items",
+          "tableTo": "parts",
+          "columnsFrom": [
+            "part_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_tracking_numbers": {
+      "name": "order_tracking_numbers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tracking_number": {
+          "name": "tracking_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "carrier": {
+          "name": "carrier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "carrier_details": {
+          "name": "carrier_details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "order_tracking_numbers_order_idx": {
+          "name": "order_tracking_numbers_order_idx",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_tracking_numbers_order_tracking_number_unique_idx": {
+          "name": "order_tracking_numbers_order_tracking_number_unique_idx",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tracking_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "order_tracking_numbers_order_id_orders_id_fk": {
+          "name": "order_tracking_numbers_order_id_orders_id_fk",
+          "tableFrom": "order_tracking_numbers",
+          "tableTo": "orders",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.orders": {
+      "name": "orders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order_number": {
+          "name": "order_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vendor_id": {
+          "name": "vendor_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quote_id": {
+          "name": "quote_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_quote_id": {
+          "name": "source_quote_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "order_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Pending'"
+        },
+        "total_price": {
+          "name": "total_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vendor_pay": {
+          "name": "vendor_pay",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_date": {
+          "name": "delivery_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_date_start": {
+          "name": "delivery_date_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lead_time_business_days_min": {
+          "name": "lead_time_business_days_min",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lead_time": {
+          "name": "lead_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "orders_customer_id_customers_id_fk": {
+          "name": "orders_customer_id_customers_id_fk",
+          "tableFrom": "orders",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "customer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "orders_vendor_id_vendors_id_fk": {
+          "name": "orders_vendor_id_vendors_id_fk",
+          "tableFrom": "orders",
+          "tableTo": "vendors",
+          "columnsFrom": [
+            "vendor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.part_drawings": {
+      "name": "part_drawings",
+      "schema": "",
+      "columns": {
+        "part_id": {
+          "name": "part_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attachment_id": {
+          "name": "attachment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "part_drawings_part_id_parts_id_fk": {
+          "name": "part_drawings_part_id_parts_id_fk",
+          "tableFrom": "part_drawings",
+          "tableTo": "parts",
+          "columnsFrom": [
+            "part_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "part_drawings_attachment_id_attachments_id_fk": {
+          "name": "part_drawings_attachment_id_attachments_id_fk",
+          "tableFrom": "part_drawings",
+          "tableTo": "attachments",
+          "columnsFrom": [
+            "attachment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "part_drawings_part_id_attachment_id_pk": {
+          "name": "part_drawings_part_id_attachment_id_pk",
+          "columns": [
+            "part_id",
+            "attachment_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.part_models": {
+      "name": "part_models",
+      "schema": "",
+      "columns": {
+        "part_id": {
+          "name": "part_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attachment_id": {
+          "name": "attachment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "part_models_part_id_parts_id_fk": {
+          "name": "part_models_part_id_parts_id_fk",
+          "tableFrom": "part_models",
+          "tableTo": "parts",
+          "columnsFrom": [
+            "part_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "part_models_attachment_id_attachments_id_fk": {
+          "name": "part_models_attachment_id_attachments_id_fk",
+          "tableFrom": "part_models",
+          "tableTo": "attachments",
+          "columnsFrom": [
+            "attachment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "part_models_part_id_attachment_id_pk": {
+          "name": "part_models_part_id_attachment_id_pk",
+          "columns": [
+            "part_id",
+            "attachment_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.parts": {
+      "name": "parts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "part_name": {
+          "name": "part_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "material": {
+          "name": "material",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tolerance": {
+          "name": "tolerance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finishing": {
+          "name": "finishing",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "part_file_url": {
+          "name": "part_file_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "part_mesh_url": {
+          "name": "part_mesh_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mesh_conversion_status": {
+          "name": "mesh_conversion_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'pending'"
+        },
+        "mesh_conversion_error": {
+          "name": "mesh_conversion_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mesh_conversion_job_id": {
+          "name": "mesh_conversion_job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mesh_conversion_started_at": {
+          "name": "mesh_conversion_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mesh_conversion_completed_at": {
+          "name": "mesh_conversion_completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "parts_customer_id_customers_id_fk": {
+          "name": "parts_customer_id_customers_id_fk",
+          "tableFrom": "parts",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "customer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quote_attachments": {
+      "name": "quote_attachments",
+      "schema": "",
+      "columns": {
+        "quote_id": {
+          "name": "quote_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attachment_id": {
+          "name": "attachment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "quote_attachments_quote_id_quotes_id_fk": {
+          "name": "quote_attachments_quote_id_quotes_id_fk",
+          "tableFrom": "quote_attachments",
+          "tableTo": "quotes",
+          "columnsFrom": [
+            "quote_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "quote_attachments_attachment_id_attachments_id_fk": {
+          "name": "quote_attachments_attachment_id_attachments_id_fk",
+          "tableFrom": "quote_attachments",
+          "tableTo": "attachments",
+          "columnsFrom": [
+            "attachment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "quote_attachments_quote_id_attachment_id_pk": {
+          "name": "quote_attachments_quote_id_attachment_id_pk",
+          "columns": [
+            "quote_id",
+            "attachment_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quote_line_items": {
+      "name": "quote_line_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "quote_id": {
+          "name": "quote_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quote_part_id": {
+          "name": "quote_part_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_price": {
+          "name": "total_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lead_time_days": {
+          "name": "lead_time_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hard_delete_at": {
+          "name": "hard_delete_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "quote_line_items_archive_purge_idx": {
+          "name": "quote_line_items_archive_purge_idx",
+          "columns": [
+            {
+              "expression": "is_archived",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hard_delete_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "quote_line_items_quote_id_quotes_id_fk": {
+          "name": "quote_line_items_quote_id_quotes_id_fk",
+          "tableFrom": "quote_line_items",
+          "tableTo": "quotes",
+          "columnsFrom": [
+            "quote_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "quote_line_items_quote_part_id_quote_parts_id_fk": {
+          "name": "quote_line_items_quote_part_id_quote_parts_id_fk",
+          "tableFrom": "quote_line_items",
+          "tableTo": "quote_parts",
+          "columnsFrom": [
+            "quote_part_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quote_part_drawings": {
+      "name": "quote_part_drawings",
+      "schema": "",
+      "columns": {
+        "quote_part_id": {
+          "name": "quote_part_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attachment_id": {
+          "name": "attachment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "quote_part_drawings_quote_part_id_quote_parts_id_fk": {
+          "name": "quote_part_drawings_quote_part_id_quote_parts_id_fk",
+          "tableFrom": "quote_part_drawings",
+          "tableTo": "quote_parts",
+          "columnsFrom": [
+            "quote_part_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "quote_part_drawings_attachment_id_attachments_id_fk": {
+          "name": "quote_part_drawings_attachment_id_attachments_id_fk",
+          "tableFrom": "quote_part_drawings",
+          "tableTo": "attachments",
+          "columnsFrom": [
+            "attachment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "quote_part_drawings_quote_part_id_attachment_id_pk": {
+          "name": "quote_part_drawings_quote_part_id_attachment_id_pk",
+          "columns": [
+            "quote_part_id",
+            "attachment_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quote_parts": {
+      "name": "quote_parts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "quote_id": {
+          "name": "quote_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "part_number": {
+          "name": "part_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "part_name": {
+          "name": "part_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "material": {
+          "name": "material",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finish": {
+          "name": "finish",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tolerance": {
+          "name": "tolerance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "part_file_url": {
+          "name": "part_file_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "part_mesh_url": {
+          "name": "part_mesh_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversion_status": {
+          "name": "conversion_status",
+          "type": "mesh_conversion_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'pending'"
+        },
+        "mesh_conversion_error": {
+          "name": "mesh_conversion_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mesh_conversion_job_id": {
+          "name": "mesh_conversion_job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mesh_conversion_started_at": {
+          "name": "mesh_conversion_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mesh_conversion_completed_at": {
+          "name": "mesh_conversion_completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "toolpath_part_id": {
+          "name": "toolpath_part_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "toolpath_report_url": {
+          "name": "toolpath_report_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "toolpath_cut_config_id": {
+          "name": "toolpath_cut_config_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "toolpath_uploaded_at": {
+          "name": "toolpath_uploaded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "toolpath_upload_error": {
+          "name": "toolpath_upload_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "toolpath_upload_status": {
+          "name": "toolpath_upload_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "toolpath_upload_job_id": {
+          "name": "toolpath_upload_job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "toolpath_queued_at": {
+          "name": "toolpath_queued_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "specifications": {
+          "name": "specifications",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hard_delete_at": {
+          "name": "hard_delete_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "quote_parts_archive_purge_idx": {
+          "name": "quote_parts_archive_purge_idx",
+          "columns": [
+            {
+              "expression": "is_archived",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hard_delete_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "quote_parts_quote_id_quotes_id_fk": {
+          "name": "quote_parts_quote_id_quotes_id_fk",
+          "tableFrom": "quote_parts",
+          "tableTo": "quotes",
+          "columnsFrom": [
+            "quote_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quote_price_calculation_templates": {
+      "name": "quote_price_calculation_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lead_time_option": {
+          "name": "lead_time_option",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "small_thread_count": {
+          "name": "small_thread_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "medium_thread_count": {
+          "name": "medium_thread_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "large_thread_count": {
+          "name": "large_thread_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "complexity_multiplier": {
+          "name": "complexity_multiplier",
+          "type": "numeric(4, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tolerance_multiplier": {
+          "name": "tolerance_multiplier",
+          "type": "numeric(4, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_global": {
+          "name": "is_global",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "quote_price_calculation_templates_created_by_users_id_fk": {
+          "name": "quote_price_calculation_templates_created_by_users_id_fk",
+          "tableFrom": "quote_price_calculation_templates",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quote_price_calculations": {
+      "name": "quote_price_calculations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "quote_id": {
+          "name": "quote_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quote_line_item_id": {
+          "name": "quote_line_item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quote_part_id": {
+          "name": "quote_part_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "toolpath_grand_total": {
+          "name": "toolpath_grand_total",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lead_time_option": {
+          "name": "lead_time_option",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lead_time_multiplier": {
+          "name": "lead_time_multiplier",
+          "type": "numeric(4, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "small_thread_count": {
+          "name": "small_thread_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "small_thread_rate": {
+          "name": "small_thread_rate",
+          "type": "numeric(6, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0.90'"
+        },
+        "medium_thread_count": {
+          "name": "medium_thread_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "medium_thread_rate": {
+          "name": "medium_thread_rate",
+          "type": "numeric(6, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0.75'"
+        },
+        "large_thread_count": {
+          "name": "large_thread_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "large_thread_rate": {
+          "name": "large_thread_rate",
+          "type": "numeric(6, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1.10'"
+        },
+        "total_thread_cost": {
+          "name": "total_thread_cost",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "complexity_multiplier": {
+          "name": "complexity_multiplier",
+          "type": "numeric(4, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tolerance_multiplier": {
+          "name": "tolerance_multiplier",
+          "type": "numeric(4, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tooling_cost": {
+          "name": "tooling_cost",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tooling_markup": {
+          "name": "tooling_markup",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_price": {
+          "name": "base_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "adjusted_price": {
+          "name": "adjusted_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "final_price": {
+          "name": "final_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "calculated_by": {
+          "name": "calculated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "quote_price_calculations_quote_id_quotes_id_fk": {
+          "name": "quote_price_calculations_quote_id_quotes_id_fk",
+          "tableFrom": "quote_price_calculations",
+          "tableTo": "quotes",
+          "columnsFrom": [
+            "quote_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "quote_price_calculations_quote_part_id_quote_parts_id_fk": {
+          "name": "quote_price_calculations_quote_part_id_quote_parts_id_fk",
+          "tableFrom": "quote_price_calculations",
+          "tableTo": "quote_parts",
+          "columnsFrom": [
+            "quote_part_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "quote_price_calculations_calculated_by_users_id_fk": {
+          "name": "quote_price_calculations_calculated_by_users_id_fk",
+          "tableFrom": "quote_price_calculations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "calculated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "quote_calc_line_item_fk": {
+          "name": "quote_calc_line_item_fk",
+          "tableFrom": "quote_price_calculations",
+          "tableTo": "quote_line_items",
+          "columnsFrom": [
+            "quote_line_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quotes": {
+      "name": "quotes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "quote_number": {
+          "name": "quote_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vendor_id": {
+          "name": "vendor_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "quote_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'RFQ'"
+        },
+        "valid_until": {
+          "name": "valid_until",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiration_days": {
+          "name": "expiration_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expired_at": {
+          "name": "expired_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subtotal": {
+          "name": "subtotal",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "converted_to_order_id": {
+          "name": "converted_to_order_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_payment_link_url": {
+          "name": "stripe_payment_link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_payment_link_id": {
+          "name": "stripe_payment_link_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_payment_link_active": {
+          "name": "stripe_payment_link_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimated_delivery_date_start": {
+          "name": "estimated_delivery_date_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimated_delivery_date_end": {
+          "name": "estimated_delivery_date_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lead_time_business_days_min": {
+          "name": "lead_time_business_days_min",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lead_time_business_days_max": {
+          "name": "lead_time_business_days_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "quotes_customer_id_customers_id_fk": {
+          "name": "quotes_customer_id_customers_id_fk",
+          "tableFrom": "quotes",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "customer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "quotes_vendor_id_vendors_id_fk": {
+          "name": "quotes_vendor_id_vendors_id_fk",
+          "tableFrom": "quotes",
+          "tableTo": "vendors",
+          "columnsFrom": [
+            "vendor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "quotes_created_by_id_users_id_fk": {
+          "name": "quotes_created_by_id_users_id_fk",
+          "tableFrom": "quotes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "quotes_converted_to_order_id_orders_id_fk": {
+          "name": "quotes_converted_to_order_id_orders_id_fk",
+          "tableFrom": "quotes",
+          "tableTo": "orders",
+          "columnsFrom": [
+            "converted_to_order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "quotes_quote_number_unique": {
+          "name": "quotes_quote_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "quote_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sent_email_attachments": {
+      "name": "sent_email_attachments",
+      "schema": "",
+      "columns": {
+        "sent_email_id": {
+          "name": "sent_email_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attachment_id": {
+          "name": "attachment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sent_email_attachments_email_idx": {
+          "name": "sent_email_attachments_email_idx",
+          "columns": [
+            {
+              "expression": "sent_email_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sent_email_attachments_sent_email_id_sent_emails_id_fk": {
+          "name": "sent_email_attachments_sent_email_id_sent_emails_id_fk",
+          "tableFrom": "sent_email_attachments",
+          "tableTo": "sent_emails",
+          "columnsFrom": [
+            "sent_email_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sent_email_attachments_attachment_id_attachments_id_fk": {
+          "name": "sent_email_attachments_attachment_id_attachments_id_fk",
+          "tableFrom": "sent_email_attachments",
+          "tableTo": "attachments",
+          "columnsFrom": [
+            "attachment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "sent_email_attachments_sent_email_id_attachment_id_pk": {
+          "name": "sent_email_attachments_sent_email_id_attachment_id_pk",
+          "columns": [
+            "sent_email_id",
+            "attachment_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sent_emails": {
+      "name": "sent_emails",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "quote_id": {
+          "name": "quote_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_key": {
+          "name": "context_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "sent_email_entity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_email": {
+          "name": "from_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_display_name": {
+          "name": "from_display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_addresses": {
+          "name": "to_addresses",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cc_addresses": {
+          "name": "cc_addresses",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_to": {
+          "name": "reply_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipient_override": {
+          "name": "recipient_override",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "html_body": {
+          "name": "html_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text_body": {
+          "name": "text_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "sent_email_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "sent_email_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_by_user_id": {
+          "name": "sent_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_by_user_email": {
+          "name": "sent_by_user_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "approved_by_user_id": {
+          "name": "approved_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejected_by_user_id": {
+          "name": "rejected_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejected_at": {
+          "name": "rejected_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sent_emails_quote_idx": {
+          "name": "sent_emails_quote_idx",
+          "columns": [
+            {
+              "expression": "quote_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sent_emails_status_idx": {
+          "name": "sent_emails_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sent_emails_entity_idx": {
+          "name": "sent_emails_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sent_emails_context_idx": {
+          "name": "sent_emails_context_idx",
+          "columns": [
+            {
+              "expression": "context_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sent_emails_quote_id_quotes_id_fk": {
+          "name": "sent_emails_quote_id_quotes_id_fk",
+          "tableFrom": "sent_emails",
+          "tableTo": "quotes",
+          "columnsFrom": [
+            "quote_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sent_emails_sent_by_user_id_users_id_fk": {
+          "name": "sent_emails_sent_by_user_id_users_id_fk",
+          "tableFrom": "sent_emails",
+          "tableTo": "users",
+          "columnsFrom": [
+            "sent_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sent_emails_approved_by_user_id_users_id_fk": {
+          "name": "sent_emails_approved_by_user_id_users_id_fk",
+          "tableFrom": "sent_emails",
+          "tableTo": "users",
+          "columnsFrom": [
+            "approved_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sent_emails_rejected_by_user_id_users_id_fk": {
+          "name": "sent_emails_rejected_by_user_id_users_id_fk",
+          "tableFrom": "sent_emails",
+          "tableTo": "users",
+          "columnsFrom": [
+            "rejected_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sent_emails_idempotency_key_unique": {
+          "name": "sent_emails_idempotency_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "idempotency_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'User'"
+        },
+        "status": {
+          "name": "status",
+          "type": "user_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vendor_attachments": {
+      "name": "vendor_attachments",
+      "schema": "",
+      "columns": {
+        "vendor_id": {
+          "name": "vendor_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attachment_id": {
+          "name": "attachment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "vendor_attachments_vendor_id_vendors_id_fk": {
+          "name": "vendor_attachments_vendor_id_vendors_id_fk",
+          "tableFrom": "vendor_attachments",
+          "tableTo": "vendors",
+          "columnsFrom": [
+            "vendor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vendor_attachments_attachment_id_attachments_id_fk": {
+          "name": "vendor_attachments_attachment_id_attachments_id_fk",
+          "tableFrom": "vendor_attachments",
+          "tableTo": "attachments",
+          "columnsFrom": [
+            "attachment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "vendor_attachments_vendor_id_attachment_id_pk": {
+          "name": "vendor_attachments_vendor_id_attachment_id_pk",
+          "columns": [
+            "vendor_id",
+            "attachment_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vendors": {
+      "name": "vendors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_name": {
+          "name": "company_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_name": {
+          "name": "contact_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_primary_contact": {
+          "name": "is_primary_contact",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "billing_address_line1": {
+          "name": "billing_address_line1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_address_line2": {
+          "name": "billing_address_line2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_city": {
+          "name": "billing_city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_state": {
+          "name": "billing_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_postal_code": {
+          "name": "billing_postal_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_country": {
+          "name": "billing_country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'US'"
+        },
+        "shipping_address_line1": {
+          "name": "shipping_address_line1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shipping_address_line2": {
+          "name": "shipping_address_line2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shipping_city": {
+          "name": "shipping_city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shipping_state": {
+          "name": "shipping_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shipping_postal_code": {
+          "name": "shipping_postal_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shipping_country": {
+          "name": "shipping_country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'US'"
+        },
+        "payment_terms": {
+          "name": "payment_terms",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_id": {
+          "name": "discord_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "vendors_company_name_idx": {
+          "name": "vendors_company_name_idx",
+          "columns": [
+            {
+              "expression": "company_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.attachment_document_kind": {
+      "name": "attachment_document_kind",
+      "schema": "public",
+      "values": [
+        "quote",
+        "invoice",
+        "purchase_order",
+        "packing_slip"
+      ]
+    },
+    "public.attachment_source": {
+      "name": "attachment_source",
+      "schema": "public",
+      "values": [
+        "user_upload",
+        "generated",
+        "system"
+      ]
+    },
+    "public.communication_method": {
+      "name": "communication_method",
+      "schema": "public",
+      "values": [
+        "call",
+        "text",
+        "email",
+        "social_media_dm"
+      ]
+    },
+    "public.email_setting_kind": {
+      "name": "email_setting_kind",
+      "schema": "public",
+      "values": [
+        "operational",
+        "merge"
+      ]
+    },
+    "public.event_category": {
+      "name": "event_category",
+      "schema": "public",
+      "values": [
+        "status",
+        "document",
+        "financial",
+        "communication",
+        "system",
+        "quality",
+        "manufacturing"
+      ]
+    },
+    "public.lead_time": {
+      "name": "lead_time",
+      "schema": "public",
+      "values": [
+        "Standard",
+        "Expedited",
+        "Custom"
+      ]
+    },
+    "public.mesh_conversion_status": {
+      "name": "mesh_conversion_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "queued",
+        "in_progress",
+        "completed",
+        "failed",
+        "skipped"
+      ]
+    },
+    "public.order_status": {
+      "name": "order_status",
+      "schema": "public",
+      "values": [
+        "Pending",
+        "Waiting_For_Shop_Selection",
+        "In_Production",
+        "In_Inspection",
+        "Shipped",
+        "Delivered",
+        "Completed",
+        "Cancelled",
+        "Archived"
+      ]
+    },
+    "public.quote_status": {
+      "name": "quote_status",
+      "schema": "public",
+      "values": [
+        "RFQ",
+        "Draft",
+        "Sent",
+        "Accepted",
+        "Rejected",
+        "Dropped",
+        "Expired"
+      ]
+    },
+    "public.sent_email_entity_type": {
+      "name": "sent_email_entity_type",
+      "schema": "public",
+      "values": [
+        "quote",
+        "order",
+        "invoice"
+      ]
+    },
+    "public.sent_email_source": {
+      "name": "sent_email_source",
+      "schema": "public",
+      "values": [
+        "user",
+        "system"
+      ]
+    },
+    "public.sent_email_status": {
+      "name": "sent_email_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "sending",
+        "sent",
+        "failed",
+        "bounced",
+        "pending_approval",
+        "rejected"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "User",
+        "Admin",
+        "Dev"
+      ]
+    },
+    "public.user_status": {
+      "name": "user_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "active",
+        "disabled"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -134,6 +134,13 @@
       "when": 1783388875344,
       "tag": "0018_thankful_skin",
       "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "7",
+      "when": 1783735203196,
+      "tag": "0019_wild_molly_hayes",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## What changed?

 - Adds a lightweight CRM communication log at /crm with a paginated,
   customer-filterable list
 - Lets users log call / text / email / social DM contacts via a modal, with
   searchable customer pickers
 - Adds a customer_communications table and writes a matching communication
   event for audit continuity
 - Adds a CRM sidebar item (BookUser icon, under Email)

## Type

- [ ] Bug fix
- [x] New feature
- [ ] Refactor/cleanup
- [ ] Other

## Related issue

Closes #

## Checklist

- [x] Tested locally
- [x] No lint/type errors
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a CRM area for viewing customer communications.
  * Added filtering by customer and pagination.
  * Added the ability to log calls, texts, emails, and social media messages with notes.
  * Added CRM navigation to the sidebar.
* **Bug Fixes**
  * Enabled secure authentication redirects to the new CRM area.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->