### PR TITLE
fix: imlement *_FILE based variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,15 @@ DATABASE_DIRECT_URL=your_postgres_url_port:5432
 # Optional: max postgres.js pool size (default 3 on Supabase session pooler, else 10)
 # DATABASE_POOL_MAX=3
 
+# Optional: Docker Swarm / Compose file-based secrets (file wins when set)
+# DATABASE_URL_FILE=/run/secrets/database_url
+# DATABASE_DIRECT_URL_FILE=/run/secrets/database_direct_url
+# SUPABASE_SERVICE_ROLE_KEY_FILE=/run/secrets/supabase_service_role_key
+# S3_SECRET_ACCESS_KEY_FILE=/run/secrets/s3_secret_access_key
+# STRIPE_SECRET_KEY_FILE=/run/secrets/stripe_secret_key
+# TOOLPATH_API_KEY_FILE=/run/secrets/toolpath_api_key
+# POSTMARK_API_TOKEN_FILE=/run/secrets/postmark_api_token
+
 S3_ENDPOINT=your_s3_endpoint
 S3_REGION=your_s3_region
 S3_ACCESS_KEY_ID=your_s3_access_key_id

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ node_modules
 /.cache
 /build
 .env
+.env.bak
+.secrets/
 # Python bytecode
 __pycache__/
 *.py[cod]
@@ -129,9 +131,3 @@ CLAUDE.md
 
 /planning
 /logs
-/scripts
-!/scripts/
-/scripts/*
-!/scripts/worker.ts
-!/scripts/prepare-husky.mjs
-!/scripts/build-worker.mjs

--- a/app/lib/auth.server.ts
+++ b/app/lib/auth.server.ts
@@ -1,4 +1,4 @@
-import { createServerClient } from "./supabase";
+import { createServerClient } from "./supabase.server";
 import { redirect } from "@remix-run/node";
 import { ensureUserExists } from "./users";
 

--- a/app/lib/config.server.ts
+++ b/app/lib/config.server.ts
@@ -1,11 +1,12 @@
 import packageJson from "../../package.json";
+import { getEnv } from "./env.server";
 
 function formatVersion(raw: string): string {
   return raw.startsWith("v") ? raw : `v${raw}`;
 }
 
 export function getAppConfig() {
-  const rawVersion = process.env.RELEASE_VERSION || packageJson.version;
+  const rawVersion = getEnv("RELEASE_VERSION") || packageJson.version;
   return {
     // Use RELEASE_VERSION env var in production, fallback to package.json for local development
     version: formatVersion(rawVersion),

--- a/app/lib/connection-string.test.ts
+++ b/app/lib/connection-string.test.ts
@@ -7,6 +7,7 @@ import {
   getQueueDatabaseUrl,
   isSupabaseSessionPooler,
 } from "./db/connection-string.server";
+import { clearEnvCache } from "./env.server";
 
 describe("connection-string.server", () => {
   it("detects Supabase session pooler on port 5432", () => {
@@ -27,9 +28,11 @@ describe("connection-string.server", () => {
     const prevDirect = process.env.DATABASE_DIRECT_URL;
     process.env.DATABASE_URL = "postgresql://pooler:5432/db";
     process.env.DATABASE_DIRECT_URL = "postgresql://direct:5432/db";
+    clearEnvCache();
     expect(getQueueDatabaseUrl()).toBe("postgresql://direct:5432/db");
     process.env.DATABASE_URL = prevPooler;
     process.env.DATABASE_DIRECT_URL = prevDirect;
+    clearEnvCache();
   });
 
   it("uses a smaller default pool on session pooler", () => {
@@ -38,9 +41,11 @@ describe("connection-string.server", () => {
     delete process.env.DATABASE_POOL_MAX;
     process.env.DATABASE_URL =
       "postgresql://user:pass@aws-0-us-east-1.pooler.supabase.com:5432/postgres";
+    clearEnvCache();
     expect(getAppDatabaseMaxConnections()).toBe(3);
     process.env.DATABASE_URL = prevPooler;
     process.env.DATABASE_POOL_MAX = prevMax;
+    clearEnvCache();
   });
 });
 

--- a/app/lib/connection-string.test.ts
+++ b/app/lib/connection-string.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   formatToolpathQueueError,
 } from "./toolpath-upload.server";
@@ -10,6 +10,33 @@ import {
 import { clearEnvCache } from "./env.server";
 
 describe("connection-string.server", () => {
+  const prev = {
+    DATABASE_URL: process.env.DATABASE_URL,
+    DATABASE_URL_FILE: process.env.DATABASE_URL_FILE,
+    DATABASE_DIRECT_URL: process.env.DATABASE_DIRECT_URL,
+    DATABASE_DIRECT_URL_FILE: process.env.DATABASE_DIRECT_URL_FILE,
+    DATABASE_POOL_MAX: process.env.DATABASE_POOL_MAX,
+    DATABASE_POOL_MAX_FILE: process.env.DATABASE_POOL_MAX_FILE,
+  };
+
+  beforeEach(() => {
+    delete process.env.DATABASE_URL_FILE;
+    delete process.env.DATABASE_DIRECT_URL_FILE;
+    delete process.env.DATABASE_POOL_MAX_FILE;
+    clearEnvCache();
+  });
+
+  afterEach(() => {
+    for (const [key, value] of Object.entries(prev)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+    clearEnvCache();
+  });
+
   it("detects Supabase session pooler on port 5432", () => {
     expect(
       isSupabaseSessionPooler(
@@ -24,28 +51,18 @@ describe("connection-string.server", () => {
   });
 
   it("prefers DATABASE_DIRECT_URL for pg-boss", () => {
-    const prevPooler = process.env.DATABASE_URL;
-    const prevDirect = process.env.DATABASE_DIRECT_URL;
     process.env.DATABASE_URL = "postgresql://pooler:5432/db";
     process.env.DATABASE_DIRECT_URL = "postgresql://direct:5432/db";
     clearEnvCache();
     expect(getQueueDatabaseUrl()).toBe("postgresql://direct:5432/db");
-    process.env.DATABASE_URL = prevPooler;
-    process.env.DATABASE_DIRECT_URL = prevDirect;
-    clearEnvCache();
   });
 
   it("uses a smaller default pool on session pooler", () => {
-    const prevPooler = process.env.DATABASE_URL;
-    const prevMax = process.env.DATABASE_POOL_MAX;
     delete process.env.DATABASE_POOL_MAX;
     process.env.DATABASE_URL =
       "postgresql://user:pass@aws-0-us-east-1.pooler.supabase.com:5432/postgres";
     clearEnvCache();
     expect(getAppDatabaseMaxConnections()).toBe(3);
-    process.env.DATABASE_URL = prevPooler;
-    process.env.DATABASE_POOL_MAX = prevMax;
-    clearEnvCache();
   });
 });
 

--- a/app/lib/conversion-service.server.ts
+++ b/app/lib/conversion-service.server.ts
@@ -4,6 +4,8 @@
  * Service is completely optional - app works without it
  */
 
+import { getEnv } from "./env.server";
+
 export interface ConversionResponse {
   job_id: string;
   status: "pending" | "in_progress" | "completed" | "failed";
@@ -30,9 +32,9 @@ export interface SupportedFormats {
 }
 
 // Environment configuration
-const CONVERSION_API_URL = process.env.CONVERSION_API_URL;
-const CONVERSION_API_TIMEOUT = parseInt(process.env.CONVERSION_API_TIMEOUT || "60000");
-const CONVERSION_POLLING_INTERVAL = parseInt(process.env.CONVERSION_POLLING_INTERVAL || "2000");
+const CONVERSION_API_URL = getEnv("CONVERSION_API_URL");
+const CONVERSION_API_TIMEOUT = parseInt(getEnv("CONVERSION_API_TIMEOUT") || "60000");
+const CONVERSION_POLLING_INTERVAL = parseInt(getEnv("CONVERSION_POLLING_INTERVAL") || "2000");
 
 /**
  * Create a timeout wrapper for fetch requests

--- a/app/lib/db/client.ts
+++ b/app/lib/db/client.ts
@@ -1,12 +1,13 @@
 import { drizzle } from "drizzle-orm/postgres-js";
 import postgres from "postgres";
 import * as schema from "./schema.js";
+import { getEnv } from "../env.server.js";
 import {
   getAppDatabaseMaxConnections,
   isSupabaseSessionPooler,
 } from "./connection-string.server.js";
 
-const connectionString = process.env.DATABASE_URL ?? "";
+const connectionString = getEnv("DATABASE_URL") ?? "";
 
 /** Transaction pooler / PgBouncer (e.g. Supabase :6543) breaks prepared statements for some queries. */
 const useTransactionPool =
@@ -17,11 +18,11 @@ const useTransactionPool =
 // All remote/Supabase connections still require SSL.
 const isLocalHost = /localhost|127\.0\.0\.1/.test(connectionString);
 const sslMode: "require" | false =
-  isLocalHost || process.env.DATABASE_SSL === "false" ? false : "require";
+  isLocalHost || getEnv("DATABASE_SSL") === "false" ? false : "require";
 
 if (
   isSupabaseSessionPooler(connectionString) &&
-  !process.env.DATABASE_DIRECT_URL
+  !getEnv("DATABASE_DIRECT_URL")
 ) {
   console.warn(
     "[DB] DATABASE_URL uses Supabase session pooler without DATABASE_DIRECT_URL. " +
@@ -38,6 +39,6 @@ export const client = postgres(connectionString, {
     application_name: "subtract-admin",
     statement_timeout: 60_000,
   },
-  prepare: process.env.DATABASE_USE_PREPARE === "true" ? true : !useTransactionPool,
+  prepare: getEnv("DATABASE_USE_PREPARE") === "true" ? true : !useTransactionPool,
 });
 export const db = drizzle(client, { schema });

--- a/app/lib/db/connection-string.server.ts
+++ b/app/lib/db/connection-string.server.ts
@@ -2,6 +2,8 @@
  * Postgres URLs and pool sizing for app vs queue clients.
  */
 
+import { getEnv } from "../env.server";
+
 /** Supabase session pooler (:5432) caps total clients (often 15). */
 export function isSupabaseSessionPooler(connectionString: string): boolean {
   return (
@@ -15,12 +17,12 @@ export function isSupabaseSessionPooler(connectionString: string): boolean {
  * do not exhaust the shared Supabase connection budget.
  */
 export function getAppDatabaseMaxConnections(): number {
-  const configured = process.env.DATABASE_POOL_MAX;
+  const configured = getEnv("DATABASE_POOL_MAX");
   if (configured != null && configured !== "") {
     return Math.max(1, Number(configured) || 3);
   }
 
-  const pooler = process.env.DATABASE_URL ?? "";
+  const pooler = getEnv("DATABASE_URL") ?? "";
   return isSupabaseSessionPooler(pooler) ? 3 : 10;
 }
 
@@ -33,8 +35,8 @@ export const PGBOSS_MAX_CONNECTIONS = 2;
  * the Supabase session pooler connection limit.
  */
 export function getQueueDatabaseUrl(): string {
-  const pooler = process.env.DATABASE_URL;
-  const direct = process.env.DATABASE_DIRECT_URL;
+  const pooler = getEnv("DATABASE_URL");
+  const direct = getEnv("DATABASE_DIRECT_URL");
 
   return direct || pooler || "";
 }

--- a/app/lib/downloadQuoteFiles.ts
+++ b/app/lib/downloadQuoteFiles.ts
@@ -4,6 +4,7 @@ import { eq, and } from "drizzle-orm";
 import { GetObjectCommand } from "@aws-sdk/client-s3";
 import { getS3Client, extractS3Key } from "./s3.server";
 import { quotePartUsesPlaceholderCad } from "./quote-part-assets.server";
+import { getEnv } from "./env.server";
 import archiver from "archiver";
 
 interface FileToZip {
@@ -85,7 +86,7 @@ export async function downloadQuoteFiles(quoteId: number) {
           try {
             const s3Key = extractS3Key(part.partFileUrl!);
             const command = new GetObjectCommand({
-              Bucket: process.env.S3_BUCKET!,
+              Bucket: getEnv("S3_BUCKET")!,
               Key: s3Key,
             });
             const response = await s3Client.send(command);
@@ -123,7 +124,7 @@ export async function downloadQuoteFiles(quoteId: number) {
             try {
               const s3Key = extractS3Key(drawing.attachment.s3Key!);
               const command = new GetObjectCommand({
-                Bucket: process.env.S3_BUCKET!,
+                Bucket: getEnv("S3_BUCKET")!,
                 Key: s3Key,
               });
               const response = await s3Client.send(command);

--- a/app/lib/email/build-email-content.server.ts
+++ b/app/lib/email/build-email-content.server.ts
@@ -27,6 +27,7 @@ import {
 import { validateMergeTokens } from "~/lib/email/resolve";
 import { resolveActorMergeTokens } from "~/lib/email/resolve/actor-merge.server";
 import type { EmailEnqueueAuth } from "~/lib/email/handlers/quote-send-email.server";
+import { getEnv } from "~/lib/env.server";
 
 export type BuildEmailContentResult =
   | {
@@ -63,7 +64,7 @@ export function collectBodyCopyStrings(copy: Record<string, unknown>): string[] 
 }
 
 function getPublicAssetUrl(path: string): string {
-  const appUrl = process.env.PUBLIC_APP_URL?.trim();
+  const appUrl = getEnv("PUBLIC_APP_URL")?.trim();
   if (!appUrl) {
     throw new Error("PUBLIC_APP_URL must be configured to render email assets");
   }

--- a/app/lib/email/email-domains.server.ts
+++ b/app/lib/email/email-domains.server.ts
@@ -1,5 +1,7 @@
+import { getEnv } from "../env.server";
+
 export function getAllowedEmailDomains(): string[] {
-  const domainsEnv = process.env.EMAIL_DOMAIN || "";
+  const domainsEnv = getEnv("EMAIL_DOMAIN") || "";
   return domainsEnv
     .split(/[\s,]+/)
     .map((d) => d.trim().toLowerCase())

--- a/app/lib/email/postmark.server.ts
+++ b/app/lib/email/postmark.server.ts
@@ -1,8 +1,9 @@
 import type { SentEmail } from "../db/schema";
+import { getEnv } from "../env.server";
 
 const SERVER_TOKEN =
-  process.env.POSTMARK_SERVER_TOKEN ?? process.env.POSTMARK_API_TOKEN;
-const MESSAGE_STREAM = process.env.POSTMARK_MESSAGE_STREAM;
+  getEnv("POSTMARK_SERVER_TOKEN") ?? getEnv("POSTMARK_API_TOKEN");
+const MESSAGE_STREAM = getEnv("POSTMARK_MESSAGE_STREAM");
 
 /** Avoid hanging indefinitely when outbound HTTPS to Postmark is blocked or stalled. */
 const POSTMARK_REQUEST_TIMEOUT_MS = 60_000;

--- a/app/lib/email/postmark.server.ts
+++ b/app/lib/email/postmark.server.ts
@@ -2,7 +2,7 @@ import type { SentEmail } from "../db/schema";
 import { getEnv } from "../env.server";
 
 const SERVER_TOKEN =
-  getEnv("POSTMARK_SERVER_TOKEN") ?? getEnv("POSTMARK_API_TOKEN");
+  getEnv("POSTMARK_SERVER_TOKEN") || getEnv("POSTMARK_API_TOKEN");
 const MESSAGE_STREAM = getEnv("POSTMARK_MESSAGE_STREAM");
 
 /** Avoid hanging indefinitely when outbound HTTPS to Postmark is blocked or stalled. */

--- a/app/lib/env.server.test.ts
+++ b/app/lib/env.server.test.ts
@@ -1,0 +1,124 @@
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { clearEnvCache, getEnv, requireEnv } from "./env.server";
+
+const TEST_VAR = "TEST_ENV_HELPER_VAR";
+const TEST_FILE_VAR = `${TEST_VAR}_FILE`;
+
+describe("env.server", () => {
+  let tempDir: string;
+  let prevValue: string | undefined;
+  let prevFile: string | undefined;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "env-server-"));
+    prevValue = process.env[TEST_VAR];
+    prevFile = process.env[TEST_FILE_VAR];
+    delete process.env[TEST_VAR];
+    delete process.env[TEST_FILE_VAR];
+    clearEnvCache();
+  });
+
+  afterEach(() => {
+    clearEnvCache();
+    if (prevValue === undefined) delete process.env[TEST_VAR];
+    else process.env[TEST_VAR] = prevValue;
+    if (prevFile === undefined) delete process.env[TEST_FILE_VAR];
+    else process.env[TEST_FILE_VAR] = prevFile;
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("returns plain env values including empty string", () => {
+    process.env[TEST_VAR] = "from-env";
+    expect(getEnv(TEST_VAR)).toBe("from-env");
+
+    clearEnvCache();
+    process.env[TEST_VAR] = "";
+    expect(getEnv(TEST_VAR)).toBe("");
+  });
+
+  it("returns undefined when plain env is unset", () => {
+    expect(getEnv(TEST_VAR)).toBeUndefined();
+  });
+
+  it("prefers file over plain env when FOO_FILE is set", () => {
+    const secretPath = join(tempDir, "secret");
+    writeFileSync(secretPath, "from-file\n", "utf8");
+    process.env[TEST_VAR] = "from-env";
+    process.env[TEST_FILE_VAR] = secretPath;
+    expect(getEnv(TEST_VAR)).toBe("from-file");
+  });
+
+  it("trims trailing newline from secret files", () => {
+    const secretPath = join(tempDir, "secret");
+    writeFileSync(secretPath, "secret-value\r\n", "utf8");
+    process.env[TEST_FILE_VAR] = secretPath;
+    expect(getEnv(TEST_VAR)).toBe("secret-value");
+  });
+
+  it("throws when FOO_FILE path is empty or whitespace", () => {
+    process.env[TEST_FILE_VAR] = "";
+    expect(() => getEnv(TEST_VAR)).toThrow(/empty/);
+
+    clearEnvCache();
+    process.env[TEST_FILE_VAR] = "   ";
+    expect(() => getEnv(TEST_VAR)).toThrow(/empty/);
+  });
+
+  it("throws when secret file is missing and does not fall back to env", () => {
+    process.env[TEST_VAR] = "from-env";
+    process.env[TEST_FILE_VAR] = join(tempDir, "missing");
+    expect(() => getEnv(TEST_VAR)).toThrow(/Failed to read/);
+  });
+
+  it("throws when secret file is empty after trim", () => {
+    const secretPath = join(tempDir, "empty");
+    writeFileSync(secretPath, "  \n", "utf8");
+    process.env[TEST_FILE_VAR] = secretPath;
+    expect(() => getEnv(TEST_VAR)).toThrow(/empty after trimming/);
+  });
+
+  it("does not cache errors so a later successful read works", () => {
+    const secretPath = join(tempDir, "late");
+    process.env[TEST_FILE_VAR] = secretPath;
+    expect(() => getEnv(TEST_VAR)).toThrow(/Failed to read/);
+
+    writeFileSync(secretPath, "now-present\n", "utf8");
+    expect(getEnv(TEST_VAR)).toBe("now-present");
+  });
+
+  it("caches successful values and undefined", () => {
+    process.env[TEST_VAR] = "cached";
+    expect(getEnv(TEST_VAR)).toBe("cached");
+    process.env[TEST_VAR] = "changed";
+    expect(getEnv(TEST_VAR)).toBe("cached");
+
+    clearEnvCache();
+    delete process.env[TEST_VAR];
+    expect(getEnv(TEST_VAR)).toBeUndefined();
+    process.env[TEST_VAR] = "after-miss";
+    expect(getEnv(TEST_VAR)).toBeUndefined();
+  });
+
+  it("requireEnv rejects missing and whitespace-only values", () => {
+    expect(() => requireEnv(TEST_VAR)).toThrow(/Missing required/);
+
+    process.env[TEST_VAR] = "   ";
+    clearEnvCache();
+    expect(() => requireEnv(TEST_VAR)).toThrow(/Missing required/);
+
+    clearEnvCache();
+    process.env[TEST_VAR] = "ok";
+    expect(requireEnv(TEST_VAR)).toBe("ok");
+  });
+
+  it("clearEnvCache allows re-resolution after env mutation", () => {
+    process.env[TEST_VAR] = "one";
+    expect(getEnv(TEST_VAR)).toBe("one");
+    process.env[TEST_VAR] = "two";
+    clearEnvCache();
+    expect(getEnv(TEST_VAR)).toBe("two");
+  });
+});

--- a/app/lib/env.server.ts
+++ b/app/lib/env.server.ts
@@ -1,0 +1,73 @@
+import { readFileSync } from "node:fs";
+
+const cache = new Map<string, string | undefined>();
+
+function fileEnvName(name: string): string {
+  return `${name}_FILE`;
+}
+
+function readSecretFile(name: string, filePath: string): string {
+  let raw: string;
+  try {
+    raw = readFileSync(filePath, "utf8");
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `Failed to read ${fileEnvName(name)} at "${filePath}": ${detail}`,
+    );
+  }
+
+  const value = raw.trim();
+  if (!value) {
+    throw new Error(
+      `${fileEnvName(name)} at "${filePath}" is empty after trimming`,
+    );
+  }
+  return value;
+}
+
+/**
+ * Resolve an env var with Docker Swarm / Compose `*_FILE` support.
+ * If `FOO_FILE` is a non-empty path, the file wins (no fallback to `FOO`).
+ * Plain env may return `""`. Successful values and `undefined` are cached;
+ * read errors are not.
+ */
+export function getEnv(name: string): string | undefined {
+  if (cache.has(name)) {
+    return cache.get(name);
+  }
+
+  const filePath = process.env[fileEnvName(name)];
+  if (filePath !== undefined) {
+    const trimmedPath = filePath.trim();
+    if (!trimmedPath) {
+      throw new Error(
+        `${fileEnvName(name)} is set but empty; provide a file path or unset it`,
+      );
+    }
+    // Errors are intentionally not cached so a retry can re-read.
+    const value = readSecretFile(name, trimmedPath);
+    cache.set(name, value);
+    return value;
+  }
+
+  const value = process.env[name];
+  cache.set(name, value);
+  return value;
+}
+
+/**
+ * Like getEnv, but throws if the resolved value is missing or whitespace-only.
+ */
+export function requireEnv(name: string): string {
+  const value = getEnv(name);
+  if (value === undefined || value.trim() === "") {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+  return value;
+}
+
+/** Clear the in-process cache. For tests that mutate process.env / secret files. */
+export function clearEnvCache(): void {
+  cache.clear();
+}

--- a/app/lib/quotes.ts
+++ b/app/lib/quotes.ts
@@ -45,6 +45,7 @@ import {
 import { createEvent } from "./events.js";
 import { isFeatureEnabled, FEATURE_FLAGS } from "./featureFlags.js";
 import { uploadFile, copyFile } from "./s3.server.js";
+import { getEnv } from "./env.server.js";
 import { triggerQuotePartMeshConversion } from "./quote-part-mesh-converter.server.js";
 import { generatePdfThumbnail, isPdfFile } from "./pdf-thumbnail.server.js";
 import {
@@ -1842,14 +1843,15 @@ export async function createQuoteWithParts(
           }
 
           // Create attachment record
-          if (!process.env.S3_BUCKET) {
+          const s3Bucket = getEnv("S3_BUCKET");
+          if (!s3Bucket) {
             throw new Error("S3_BUCKET environment variable is not configured");
           }
 
           const [attachment] = await db
             .insert(attachments)
             .values({
-              s3Bucket: process.env.S3_BUCKET,
+              s3Bucket,
               s3Key: uploadResult.key,
               fileName: drawing.fileName,
               contentType,

--- a/app/lib/s3-migration.server.ts
+++ b/app/lib/s3-migration.server.ts
@@ -9,8 +9,9 @@ import { getS3Client } from './s3.server'
 import { db } from './db/index'
 import { quoteParts } from './db/schema'
 import { eq, like, and, isNotNull } from 'drizzle-orm'
+import { getEnv } from './env.server'
 
-const S3_BUCKET = process.env.S3_BUCKET || 'subtract-attachments'
+const S3_BUCKET = getEnv('S3_BUCKET') || 'subtract-attachments'
 
 export type MigrationResult = {
   success: boolean

--- a/app/lib/s3.server.ts
+++ b/app/lib/s3.server.ts
@@ -2,12 +2,13 @@ import { S3Client, PutObjectCommand, DeleteObjectCommand, GetObjectCommand, Head
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner'
 import { NodeHttpHandler } from '@smithy/node-http-handler'
 import https from 'https'
+import { getEnv } from './env.server'
 
-const S3_ENDPOINT = process.env.S3_ENDPOINT
-const S3_REGION = process.env.S3_REGION || 'us-east-1'
-const S3_ACCESS_KEY_ID = process.env.S3_ACCESS_KEY_ID
-const S3_SECRET_ACCESS_KEY = process.env.S3_SECRET_ACCESS_KEY
-const S3_BUCKET = process.env.S3_BUCKET || 'subtract-attachments'
+const S3_ENDPOINT = getEnv('S3_ENDPOINT')
+const S3_REGION = getEnv('S3_REGION') || 'us-east-1'
+const S3_ACCESS_KEY_ID = getEnv('S3_ACCESS_KEY_ID')
+const S3_SECRET_ACCESS_KEY = getEnv('S3_SECRET_ACCESS_KEY')
+const S3_BUCKET = getEnv('S3_BUCKET') || 'subtract-attachments'
 
 // Create S3 client lazily to avoid initialization errors
 let s3Client: S3Client | null = null

--- a/app/lib/stripe.server.ts
+++ b/app/lib/stripe.server.ts
@@ -1,18 +1,20 @@
 import Stripe from "stripe";
 import { getStripeDefaults } from "./developerSettings";
+import { getEnv } from "./env.server";
 
 let stripeClient: Stripe | null = null;
 
 export function getStripeClient(): Stripe | null {
-  if (!process.env.STRIPE_SECRET_KEY) return null;
+  const secretKey = getEnv("STRIPE_SECRET_KEY");
+  if (!secretKey) return null;
   if (!stripeClient) {
-    stripeClient = new Stripe(process.env.STRIPE_SECRET_KEY);
+    stripeClient = new Stripe(secretKey);
   }
   return stripeClient;
 }
 
 export function isStripeConfigured(): boolean {
-  return !!process.env.STRIPE_SECRET_KEY;
+  return !!getEnv("STRIPE_SECRET_KEY");
 }
 
 interface CreatePaymentLinkParams {

--- a/app/lib/supabase.admin.server.ts
+++ b/app/lib/supabase.admin.server.ts
@@ -1,7 +1,9 @@
 import { createClient } from "@supabase/supabase-js";
+import { getEnv } from "./env.server";
 
-const supabaseUrl = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL!;
-const supabaseServiceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY!;
+const supabaseUrl =
+  getEnv("SUPABASE_URL") || getEnv("NEXT_PUBLIC_SUPABASE_URL")!;
+const supabaseServiceRoleKey = getEnv("SUPABASE_SERVICE_ROLE_KEY")!;
 
 export function createAdminClient() {
   if (!supabaseServiceRoleKey) {

--- a/app/lib/supabase.server.ts
+++ b/app/lib/supabase.server.ts
@@ -1,0 +1,84 @@
+import { createServerClient as createSupabaseServerClient, parse, serialize } from '@supabase/ssr';
+import { getEnv } from './env.server';
+
+const supabaseUrl =
+  getEnv('SUPABASE_URL') || getEnv('NEXT_PUBLIC_SUPABASE_URL')!;
+const supabaseAnonKey =
+  getEnv('SUPABASE_ANON_KEY') || getEnv('NEXT_PUBLIC_SUPABASE_ANON_KEY')!;
+
+const sessionExpiryRaw = getEnv('SESSION_EXPIRY');
+const sessionExpirySeconds = sessionExpiryRaw
+  ? parseInt(sessionExpiryRaw, 10)
+  : undefined;
+
+const LAST_ACTIVITY_COOKIE = 'sb-last-activity';
+
+/** Server client for loader/action functions */
+export function createServerClient(request: Request) {
+  const cookies = parse(request.headers.get('Cookie') ?? '');
+  const headers = new Headers();
+  let sessionExpired = false;
+
+  if (sessionExpirySeconds !== undefined) {
+    const lastActivity = cookies[LAST_ACTIVITY_COOKIE];
+    if (lastActivity) {
+      const lastActivityTime = parseInt(lastActivity, 10);
+      const now = Math.floor(Date.now() / 1000);
+      const timeSinceLastActivity = now - lastActivityTime;
+
+      if (timeSinceLastActivity > sessionExpirySeconds) {
+        sessionExpired = true;
+      }
+    }
+  }
+
+  const supabase = createSupabaseServerClient(
+    supabaseUrl,
+    supabaseAnonKey,
+    {
+      cookies: {
+        get(key: string) {
+          if (sessionExpired && key.startsWith('sb-')) {
+            return null;
+          }
+          return cookies[key];
+        },
+        set(key: string, value: string, options: Parameters<typeof serialize>[2]) {
+          headers.append('Set-Cookie', serialize(key, value, options));
+        },
+        remove(key: string, options: Parameters<typeof serialize>[2]) {
+          headers.append('Set-Cookie', serialize(key, '', options));
+        },
+      },
+    }
+  );
+
+  if (!sessionExpired && sessionExpirySeconds !== undefined) {
+    const now = Math.floor(Date.now() / 1000);
+    headers.append(
+      'Set-Cookie',
+      serialize(LAST_ACTIVITY_COOKIE, now.toString(), {
+        path: '/',
+        httpOnly: true,
+        sameSite: 'lax',
+        secure: process.env.NODE_ENV === 'production',
+        maxAge: sessionExpirySeconds,
+      })
+    );
+  }
+
+  if (sessionExpired) {
+    headers.append(
+      'Set-Cookie',
+      serialize(LAST_ACTIVITY_COOKIE, '', {
+        path: '/',
+        httpOnly: true,
+        sameSite: 'lax',
+        secure: process.env.NODE_ENV === 'production',
+        maxAge: 0,
+      })
+    );
+  }
+
+  return { supabase, headers };
+}

--- a/app/lib/supabase.server.ts
+++ b/app/lib/supabase.server.ts
@@ -1,4 +1,9 @@
-import { createServerClient as createSupabaseServerClient, parse, serialize } from '@supabase/ssr';
+import {
+  createServerClient as createSupabaseServerClient,
+  parseCookieHeader,
+  serializeCookieHeader,
+} from '@supabase/ssr';
+import type { CookieOptions } from '@supabase/ssr';
 import { getEnv } from './env.server';
 
 const supabaseUrl =
@@ -7,28 +12,56 @@ const supabaseAnonKey =
   getEnv('SUPABASE_ANON_KEY') || getEnv('NEXT_PUBLIC_SUPABASE_ANON_KEY')!;
 
 const sessionExpiryRaw = getEnv('SESSION_EXPIRY');
-const sessionExpirySeconds = sessionExpiryRaw
-  ? parseInt(sessionExpiryRaw, 10)
-  : undefined;
+const parsedExpiry = sessionExpiryRaw ? parseInt(sessionExpiryRaw, 10) : NaN;
+const sessionExpirySeconds =
+  Number.isFinite(parsedExpiry) && parsedExpiry > 0
+    ? parsedExpiry
+    : undefined;
 
 const LAST_ACTIVITY_COOKIE = 'sb-last-activity';
 
+function isAuthCookie(key: string): boolean {
+  return key.startsWith('sb-') && key !== LAST_ACTIVITY_COOKIE;
+}
+
+function clearCookieOptions(): CookieOptions {
+  return {
+    path: '/',
+    httpOnly: true,
+    sameSite: 'lax',
+    secure: process.env.NODE_ENV === 'production',
+    maxAge: 0,
+  };
+}
+
 /** Server client for loader/action functions */
 export function createServerClient(request: Request) {
-  const cookies = parse(request.headers.get('Cookie') ?? '');
+  const cookieList = parseCookieHeader(request.headers.get('Cookie') ?? '');
+  const cookies: Record<string, string> = {};
+  for (const { name, value } of cookieList) {
+    cookies[name] = value ?? '';
+  }
   const headers = new Headers();
   let sessionExpired = false;
 
   if (sessionExpirySeconds !== undefined) {
     const lastActivity = cookies[LAST_ACTIVITY_COOKIE];
+    const hasAuthCookies = Object.keys(cookies).some(
+      (key) => isAuthCookie(key) && cookies[key],
+    );
+
     if (lastActivity) {
       const lastActivityTime = parseInt(lastActivity, 10);
       const now = Math.floor(Date.now() / 1000);
-      const timeSinceLastActivity = now - lastActivityTime;
-
-      if (timeSinceLastActivity > sessionExpirySeconds) {
+      if (
+        !Number.isFinite(lastActivityTime) ||
+        now - lastActivityTime > sessionExpirySeconds
+      ) {
         sessionExpired = true;
       }
+    } else if (hasAuthCookies) {
+      // Inactivity marker missing but auth cookies remain → treat as expired
+      sessionExpired = true;
     }
   }
 
@@ -38,16 +71,16 @@ export function createServerClient(request: Request) {
     {
       cookies: {
         get(key: string) {
-          if (sessionExpired && key.startsWith('sb-')) {
+          if (sessionExpired && isAuthCookie(key)) {
             return null;
           }
           return cookies[key];
         },
-        set(key: string, value: string, options: Parameters<typeof serialize>[2]) {
-          headers.append('Set-Cookie', serialize(key, value, options));
+        set(key: string, value: string, options: CookieOptions) {
+          headers.append('Set-Cookie', serializeCookieHeader(key, value, options));
         },
-        remove(key: string, options: Parameters<typeof serialize>[2]) {
-          headers.append('Set-Cookie', serialize(key, '', options));
+        remove(key: string, options: CookieOptions) {
+          headers.append('Set-Cookie', serializeCookieHeader(key, '', options));
         },
       },
     }
@@ -57,7 +90,7 @@ export function createServerClient(request: Request) {
     const now = Math.floor(Date.now() / 1000);
     headers.append(
       'Set-Cookie',
-      serialize(LAST_ACTIVITY_COOKIE, now.toString(), {
+      serializeCookieHeader(LAST_ACTIVITY_COOKIE, now.toString(), {
         path: '/',
         httpOnly: true,
         sameSite: 'lax',
@@ -68,15 +101,17 @@ export function createServerClient(request: Request) {
   }
 
   if (sessionExpired) {
+    for (const key of Object.keys(cookies)) {
+      if (isAuthCookie(key)) {
+        headers.append(
+          'Set-Cookie',
+          serializeCookieHeader(key, '', clearCookieOptions()),
+        );
+      }
+    }
     headers.append(
       'Set-Cookie',
-      serialize(LAST_ACTIVITY_COOKIE, '', {
-        path: '/',
-        httpOnly: true,
-        sameSite: 'lax',
-        secure: process.env.NODE_ENV === 'production',
-        maxAge: 0,
-      })
+      serializeCookieHeader(LAST_ACTIVITY_COOKIE, '', clearCookieOptions()),
     );
   }
 

--- a/app/lib/supabase.ts
+++ b/app/lib/supabase.ts
@@ -1,95 +1,13 @@
-import { createServerClient as createSupabaseServerClient, parse, serialize } from '@supabase/ssr';
 import { createClient } from '@supabase/supabase-js';
 
-// Get environment variables (remove NEXT_PUBLIC_ prefix)
+// Browser-reachable module: keep plain process.env (no Node fs / env.server).
 const supabaseUrl = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL!;
 const supabaseAnonKey = process.env.SUPABASE_ANON_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
 
-// Session expiry in seconds (undefined means no expiry)
-const sessionExpirySeconds = process.env.SESSION_EXPIRY
-  ? parseInt(process.env.SESSION_EXPIRY, 10)
-  : undefined;
-
-const LAST_ACTIVITY_COOKIE = 'sb-last-activity';
-
-// Browser client - only for client-side operations
+/** Browser client - only for client-side operations */
 export function createBrowserClient() {
   return createClient(
     supabaseUrl,
     supabaseAnonKey
   );
-}
-
-// Server client for loader/action functions
-export function createServerClient(request: Request) {
-  const cookies = parse(request.headers.get('Cookie') ?? '');
-  const headers = new Headers();
-  let sessionExpired = false;
-
-  // Check session expiry if configured
-  if (sessionExpirySeconds !== undefined) {
-    const lastActivity = cookies[LAST_ACTIVITY_COOKIE];
-    if (lastActivity) {
-      const lastActivityTime = parseInt(lastActivity, 10);
-      const now = Math.floor(Date.now() / 1000);
-      const timeSinceLastActivity = now - lastActivityTime;
-
-      if (timeSinceLastActivity > sessionExpirySeconds) {
-        sessionExpired = true;
-      }
-    }
-  }
-
-  const supabase = createSupabaseServerClient(
-    supabaseUrl,
-    supabaseAnonKey,
-    {
-      cookies: {
-        get(key: string) {
-          // Return null for auth cookies if session expired
-          if (sessionExpired && key.startsWith('sb-')) {
-            return null;
-          }
-          return cookies[key];
-        },
-        set(key: string, value: string, options: Parameters<typeof serialize>[2]) {
-          headers.append('Set-Cookie', serialize(key, value, options));
-        },
-        remove(key: string, options: Parameters<typeof serialize>[2]) {
-          headers.append('Set-Cookie', serialize(key, '', options));
-        },
-      },
-    }
-  );
-
-  // Update last activity timestamp if session is active and not expired
-  if (!sessionExpired && sessionExpirySeconds !== undefined) {
-    const now = Math.floor(Date.now() / 1000);
-    headers.append(
-      'Set-Cookie',
-      serialize(LAST_ACTIVITY_COOKIE, now.toString(), {
-        path: '/',
-        httpOnly: true,
-        sameSite: 'lax',
-        secure: process.env.NODE_ENV === 'production',
-        maxAge: sessionExpirySeconds,
-      })
-    );
-  }
-
-  // Clear last activity cookie if session expired
-  if (sessionExpired) {
-    headers.append(
-      'Set-Cookie',
-      serialize(LAST_ACTIVITY_COOKIE, '', {
-        path: '/',
-        httpOnly: true,
-        sameSite: 'lax',
-        secure: process.env.NODE_ENV === 'production',
-        maxAge: 0,
-      })
-    );
-  }
-
-  return { supabase, headers };
 }

--- a/app/lib/toolpath.server.test.ts
+++ b/app/lib/toolpath.server.test.ts
@@ -60,11 +60,14 @@ describe("toolpath.server", () => {
   });
 
   it("reports whether Toolpath is configured", async () => {
+    const { clearEnvCache } = await import("./env.server");
+    clearEnvCache();
     const { isToolpathEnabled } = await import("./toolpath.server");
 
     expect(isToolpathEnabled()).toBe(true);
 
     delete process.env.TOOLPATH_API_KEY;
+    clearEnvCache();
 
     expect(isToolpathEnabled()).toBe(false);
   });

--- a/app/lib/toolpath.server.test.ts
+++ b/app/lib/toolpath.server.test.ts
@@ -54,11 +54,13 @@ describe("toolpath.server", () => {
   const prevToolpathKey = process.env.TOOLPATH_API_KEY;
   const prevToolpathKeyFile = process.env.TOOLPATH_API_KEY_FILE;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.resetModules();
     vi.clearAllMocks();
     delete process.env.TOOLPATH_API_KEY_FILE;
     process.env.TOOLPATH_API_KEY = "tp_test_123";
+    const { clearEnvCache } = await import("./env.server");
+    clearEnvCache();
     globalThis.fetch = vi.fn();
     vi.useRealTimers();
   });
@@ -521,6 +523,17 @@ describe("toolpath.server", () => {
 });
 
 describe("pollToolpathReportUrl", () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    delete process.env.TOOLPATH_API_KEY_FILE;
+    process.env.TOOLPATH_API_KEY = "tp_test_123";
+    const { clearEnvCache } = await import("./env.server");
+    clearEnvCache();
+    globalThis.fetch = vi.fn();
+    vi.useRealTimers();
+  });
+
   it("returns report URL when part becomes ready", async () => {
     const readyPartBody = {
       data: {

--- a/app/lib/toolpath.server.test.ts
+++ b/app/lib/toolpath.server.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const downloadFromS3 = vi.fn();
 
@@ -51,12 +51,29 @@ function mockReadyReportPolling(
 }
 
 describe("toolpath.server", () => {
+  const prevToolpathKey = process.env.TOOLPATH_API_KEY;
+  const prevToolpathKeyFile = process.env.TOOLPATH_API_KEY_FILE;
+
   beforeEach(() => {
     vi.resetModules();
     vi.clearAllMocks();
+    delete process.env.TOOLPATH_API_KEY_FILE;
     process.env.TOOLPATH_API_KEY = "tp_test_123";
     globalThis.fetch = vi.fn();
     vi.useRealTimers();
+  });
+
+  afterEach(() => {
+    if (prevToolpathKey === undefined) {
+      delete process.env.TOOLPATH_API_KEY;
+    } else {
+      process.env.TOOLPATH_API_KEY = prevToolpathKey;
+    }
+    if (prevToolpathKeyFile === undefined) {
+      delete process.env.TOOLPATH_API_KEY_FILE;
+    } else {
+      process.env.TOOLPATH_API_KEY_FILE = prevToolpathKeyFile;
+    }
   });
 
   it("reports whether Toolpath is configured", async () => {

--- a/app/lib/toolpath.server.ts
+++ b/app/lib/toolpath.server.ts
@@ -1,4 +1,5 @@
 import { downloadFromS3 } from "./s3.server";
+import { getEnv } from "./env.server";
 
 const TOOLPATH_API_BASE = "https://app.toolpath.com/api/public/v0";
 /** Toolpath allows one POST /parts every 2 seconds per team. */
@@ -129,7 +130,7 @@ type ToolpathRequestInit = RequestInit & {
 };
 
 export function isToolpathEnabled(): boolean {
-  return !!process.env.TOOLPATH_API_KEY;
+  return !!getEnv("TOOLPATH_API_KEY");
 }
 
 async function parseToolpathError(response: Response): Promise<string> {
@@ -150,7 +151,7 @@ async function toolpathFetch(
   init: ToolpathRequestInit = {},
   options: { pacePartCreation?: boolean } = {},
 ): Promise<Response> {
-  const key = process.env.TOOLPATH_API_KEY;
+  const key = getEnv("TOOLPATH_API_KEY");
   if (!key) throw new Error("Toolpath API not configured");
 
   const method = (init.method ?? "GET").toUpperCase();

--- a/app/routes/_protected+/_layout.tsx
+++ b/app/routes/_protected+/_layout.tsx
@@ -1,7 +1,7 @@
 import { LoaderFunctionArgs, ActionFunctionArgs, json, redirect } from "@remix-run/node";
 import { Outlet, useLoaderData, useLocation } from "@remix-run/react";
 import { requireAuth, withAuthHeaders, canUsePartAssetAdmin } from "~/lib/auth.server";
-import { createServerClient } from "~/lib/supabase";
+import { createServerClient } from "~/lib/supabase.server";
 import { getAppConfig } from "~/lib/config.server";
 import { canUserAccessAdminConsole, shouldShowEventsInNav, shouldShowVersionInHeader, isOutboundEmailEnabled } from "~/lib/featureFlags";
 import { getEmailSettings } from "~/lib/email/templates.server";

--- a/app/routes/_protected.orders.$orderId.tsx
+++ b/app/routes/_protected.orders.$orderId.tsx
@@ -77,6 +77,7 @@ import {
   deleteFile,
   getDownloadUrl,
 } from "~/lib/s3.server";
+import { getEnv } from "~/lib/env.server";
 import { generateDocumentPdf } from "~/lib/pdf-service.server";
 import { generatePdfThumbnail, isPdfFile } from "~/lib/pdf-thumbnail.server";
 import Button from "~/components/shared/Button";
@@ -940,7 +941,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
               const [attachment] = await db
                 .insert(attachments)
                 .values({
-                  s3Bucket: process.env.S3_BUCKET || "default-bucket",
+                  s3Bucket: getEnv("S3_BUCKET") || "default-bucket",
                   s3Key: drawingUpload.key,
                   fileName: drawing.name,
                   contentType: drawing.type || "application/pdf",
@@ -1804,7 +1805,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
               const [attachment] = await db
                 .insert(attachments)
                 .values({
-                  s3Bucket: process.env.S3_BUCKET || "default-bucket",
+                  s3Bucket: getEnv("S3_BUCKET") || "default-bucket",
                   s3Key: uploadResult.key,
                   fileName: drawing.name,
                   contentType: drawing.type || "application/pdf",

--- a/app/routes/_protected.quotes.$quoteId.tsx
+++ b/app/routes/_protected.quotes.$quoteId.tsx
@@ -58,6 +58,7 @@ import {
   getDownloadUrl,
   extractS3Key,
 } from "~/lib/s3.server";
+import { getEnv } from "~/lib/env.server";
 import {
   getBananaModelUrls,
   getPlaceholderPartUrls,
@@ -688,7 +689,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
             const [attachment] = await db
               .insert(attachments)
               .values({
-                s3Bucket: process.env.S3_BUCKET || "default-bucket",
+                s3Bucket: getEnv("S3_BUCKET") || "default-bucket",
                 s3Key: drawingUploadResult.key,
                 fileName: file.name,
                 contentType: drawingContentType,
@@ -747,7 +748,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
                   const [att2] = await db
                     .insert(attachments)
                     .values({
-                      s3Bucket: process.env.S3_BUCKET || "default-bucket",
+                      s3Bucket: getEnv("S3_BUCKET") || "default-bucket",
                       s3Key: dUpload.key,
                       fileName: drawing.name,
                       contentType: ct,
@@ -884,7 +885,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
                   const [attachment] = await db
                     .insert(attachments)
                     .values({
-                      s3Bucket: process.env.S3_BUCKET || "default-bucket",
+                      s3Bucket: getEnv("S3_BUCKET") || "default-bucket",
                       s3Key: drawingUploadResult.key,
                       fileName: drawing.name,
                       contentType: drawing.type || "application/pdf",
@@ -1061,7 +1062,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
             const [attachment] = await db
               .insert(attachments)
               .values({
-                s3Bucket: process.env.S3_BUCKET || "default-bucket",
+                s3Bucket: getEnv("S3_BUCKET") || "default-bucket",
                 s3Key: drawingUploadResult.key,
                 fileName: drawing.name,
                 contentType: drawing.type || "application/pdf",

--- a/app/routes/_protected.settings.tsx
+++ b/app/routes/_protected.settings.tsx
@@ -11,7 +11,7 @@ import { useDownload } from "~/hooks/useDownload";
 import Modal from "~/components/shared/Modal";
 import { requireAuth, withAuthHeaders } from "~/lib/auth.server";
 import { getAppConfig } from "~/lib/config.server";
-import { createServerClient } from "~/lib/supabase";
+import { createServerClient } from "~/lib/supabase.server";
 import Button from "~/components/shared/Button";
 import { InputField } from "~/components/shared/FormField";
 import {

--- a/app/routes/auth.callback.tsx
+++ b/app/routes/auth.callback.tsx
@@ -1,5 +1,5 @@
 import { LoaderFunctionArgs, redirect } from "@remix-run/node";
-import { createServerClient } from "~/lib/supabase";
+import { createServerClient } from "~/lib/supabase.server";
 import { withAuthHeaders } from "~/lib/auth.server";
 import { getSafeRedirectUrl, isAllowedAuthRedirect } from "~/lib/url-validator";
 

--- a/app/routes/health.tsx
+++ b/app/routes/health.tsx
@@ -1,5 +1,6 @@
 import type { LoaderFunction } from "@remix-run/node";
 import { json } from "@remix-run/node";
+import { getEnv } from "~/lib/env.server";
 
 export const loader: LoaderFunction = async () => {
   return json(
@@ -7,7 +8,7 @@ export const loader: LoaderFunction = async () => {
       status: "healthy",
       timestamp: new Date().toISOString(),
       service: "subtract-frontend",
-      version: process.env.RELEASE_VERSION || "Unable to load version",
+      version: getEnv("RELEASE_VERSION") || "Unable to load version",
     },
     {
       status: 200,

--- a/app/routes/login.tsx
+++ b/app/routes/login.tsx
@@ -1,7 +1,7 @@
 import { ActionFunctionArgs, LoaderFunctionArgs, json, redirect } from "@remix-run/node";
 import { Form, useActionData, useNavigation, useLoaderData, useNavigate } from "@remix-run/react";
 import { useEffect } from "react";
-import { createServerClient } from "~/lib/supabase";
+import { createServerClient } from "~/lib/supabase.server";
 import { withAuthHeaders } from "~/lib/auth.server";
 import { styles } from "~/utils/tw-styles";
 import { loginRateLimiter } from "~/lib/rate-limiter";

--- a/app/routes/logout.tsx
+++ b/app/routes/logout.tsx
@@ -1,5 +1,5 @@
 import { ActionFunctionArgs, redirect } from "@remix-run/node";
-import { createServerClient } from "~/lib/supabase";
+import { createServerClient } from "~/lib/supabase.server";
 import { withAuthHeaders } from "~/lib/auth.server";
 
 export async function action({ request }: ActionFunctionArgs) {

--- a/app/routes/setup-password.tsx
+++ b/app/routes/setup-password.tsx
@@ -1,7 +1,7 @@
 import { ActionFunctionArgs, LoaderFunctionArgs, json, redirect } from "@remix-run/node";
 import { Form, useActionData, useFetcher, useLoaderData, useNavigation } from "@remix-run/react";
 import { useEffect, useMemo, useRef, useState } from "react";
-import { createServerClient } from "~/lib/supabase";
+import { createServerClient } from "~/lib/supabase.server";
 import { withAuthHeaders } from "~/lib/auth.server";
 import { styles, formStyles } from "~/utils/tw-styles";
 import {

--- a/docker/.env.docker.example
+++ b/docker/.env.docker.example
@@ -5,6 +5,9 @@ DATABASE_URL=postgresql://subtract:subtract_dev_password@postgres:5432/subtract_
 # For production, use your actual PostgreSQL connection string
 # DATABASE_URL=postgresql://user:password@host:port/database
 
+# Optional: Docker Swarm / Compose file-based secrets (file wins when FOO_FILE is set)
+# DATABASE_URL_FILE=/run/secrets/database_url
+
 # Supabase Configuration (if using Supabase)
 NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key

--- a/docker/README.md
+++ b/docker/README.md
@@ -80,6 +80,27 @@ Required variables:
 - `NEXT_PUBLIC_SUPABASE_URL` - Supabase URL
 - `NEXT_PUBLIC_SUPABASE_ANON_KEY` - Supabase anonymous key
 
+### File-based secrets (`*_FILE`) for Docker Swarm / Compose
+
+App-owned config is resolved via `getEnv` / `requireEnv` (`app/lib/env.server.ts`).
+For any variable `FOO`, you may set `FOO_FILE` to a path whose contents become the value:
+
+```bash
+# Swarm / Compose secrets (file wins over plain env when FOO_FILE is set)
+DATABASE_URL_FILE=/run/secrets/database_url
+DATABASE_DIRECT_URL_FILE=/run/secrets/database_direct_url
+SUPABASE_SERVICE_ROLE_KEY_FILE=/run/secrets/supabase_service_role_key
+S3_SECRET_ACCESS_KEY_FILE=/run/secrets/s3_secret_access_key
+STRIPE_SECRET_KEY_FILE=/run/secrets/stripe_secret_key
+```
+
+Rules:
+- If `FOO_FILE` is a non-empty path, the file **wins** — there is no fallback to `FOO` if the file is missing, unreadable, or empty.
+- An empty/`""` `FOO_FILE` is an error; unset `FOO_FILE` to use plain `FOO` instead.
+- Local/dev can keep using plain env vars (or `.env`); `*_FILE` is optional.
+
+**Infra follow-up:** production compose lives in `SubtractManufacturing/infra`. Mount Docker secrets and pass `*_FILE=/run/secrets/...` there when adopting Swarm secrets; no compose change is required in this repo for the app helper to work.
+
 ## Container Management
 
 ### View Logs

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,5 +1,6 @@
 import "dotenv/config";
 import { defineConfig } from "drizzle-kit";
+import { getEnv } from "./app/lib/env.server";
 
 export default defineConfig({
   dialect: "postgresql",
@@ -7,6 +8,6 @@ export default defineConfig({
   out: "./drizzle",
   dbCredentials: {
     // Prefer session pooler (DATABASE_URL) — see getQueueDatabaseUrl() for pg-boss.
-    url: process.env.DATABASE_URL || process.env.DATABASE_DIRECT_URL!,
+    url: getEnv("DATABASE_URL") || getEnv("DATABASE_DIRECT_URL")!,
   },
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -5871,9 +5871,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -10662,9 +10662,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -137,6 +137,8 @@
     "minimatch": "^10.0.0",
     "tar": ">=7.6.0",
     "cacache": ">=19.0.0",
-    "basic-ftp": ">=5.3.1"
+    "basic-ftp": ">=5.3.1",
+    "brace-expansion": "^5.0.7",
+    "js-yaml": "^4.3.0"
   }
 }

--- a/scripts/check-db.ts
+++ b/scripts/check-db.ts
@@ -3,6 +3,8 @@ import { drizzle } from 'drizzle-orm/postgres-js';
 import postgres from 'postgres';
 import { sql } from 'drizzle-orm';
 
+type InfoRow = Record<string, unknown>;
+
 async function checkDatabase() {
   console.log('Checking database connection and schema...\n');
   
@@ -19,8 +21,9 @@ async function checkDatabase() {
   try {
     // Test connection
     const result = await db.execute(sql`SELECT current_database()`);
+    const dbRows = result as unknown as InfoRow[];
     console.log('✅ Database connection successful');
-    console.log(`Connected to database: ${(result as any)[0].current_database}\n`);
+    console.log(`Connected to database: ${String(dbRows[0]?.current_database)}\n`);
     
     // Check if users table exists
     const tables = await db.execute(sql`
@@ -30,12 +33,13 @@ async function checkDatabase() {
       AND table_type = 'BASE TABLE'
     `);
     
+    const tableRows = tables as unknown as InfoRow[];
     console.log('📋 Existing tables:');
-    (tables as any).forEach((row: any) => console.log(`  - ${row.table_name}`));
+    tableRows.forEach((row) => console.log(`  - ${String(row.table_name)}`));
     console.log('');
     
     // Check users table schema
-    const userTableExists = (tables as any).some((row: any) => row.table_name === 'users');
+    const userTableExists = tableRows.some((row) => row.table_name === 'users');
     if (userTableExists) {
       const columns = await db.execute(sql`
         SELECT column_name, data_type, is_nullable
@@ -45,13 +49,14 @@ async function checkDatabase() {
         ORDER BY ordinal_position
       `);
       
+      const columnRows = columns as unknown as InfoRow[];
       console.log('📊 Users table columns:');
-      (columns as any).forEach((row: any) => {
-        console.log(`  - ${row.column_name} (${row.data_type}) ${row.is_nullable === 'NO' ? 'NOT NULL' : 'NULL'}`);
+      columnRows.forEach((row) => {
+        console.log(`  - ${String(row.column_name)} (${String(row.data_type)}) ${row.is_nullable === 'NO' ? 'NOT NULL' : 'NULL'}`);
       });
       
       // Check if password_hash exists
-      const hasPasswordHash = (columns as any).some((row: any) => row.column_name === 'password_hash');
+      const hasPasswordHash = columnRows.some((row) => row.column_name === 'password_hash');
       
       if (hasPasswordHash) {
         console.log('\n⚠️  Found password_hash column. Removing it...');

--- a/scripts/check-supabase-connection.ts
+++ b/scripts/check-supabase-connection.ts
@@ -10,7 +10,7 @@ if (!dbUrl) {
 }
 
 // Parse the connection string - handle both postgres:// and postgresql://
-const urlMatch = dbUrl.match(/(?:postgresql|postgres):\/\/([^:]+):([^@]+)@([^:\/]+):(\d+)\/(.+?)(\?.*)?$/);
+const urlMatch = dbUrl.match(/(?:postgresql|postgres):\/\/([^:]+):([^@]+)@([^:/]+):(\d+)\/(.+?)(\?.*)?$/);
 
 if (!urlMatch) {
   console.error('❌ DATABASE_URL format is invalid');

--- a/scripts/convert-env-to-files.sh
+++ b/scripts/convert-env-to-files.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+# Convert getEnv/requireEnv keys in .env to KEY_FILE=.secrets/KEY for local *_FILE testing.
+# Usage:
+#   bash scripts/convert-env-to-files.sh
+#   bash scripts/convert-env-to-files.sh --restore
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ENV_FILE="$ROOT/.env"
+BACKUP_FILE="$ROOT/.env.bak"
+SECRETS_DIR="$ROOT/.secrets"
+
+# Keys resolved via getEnv / requireEnv (app/lib/env.server.ts consumers).
+ALLOWLIST=(
+  DATABASE_URL
+  DATABASE_DIRECT_URL
+  DATABASE_SSL
+  DATABASE_USE_PREPARE
+  DATABASE_POOL_MAX
+  SUPABASE_URL
+  SUPABASE_SERVICE_ROLE_KEY
+  SUPABASE_ANON_KEY
+  NEXT_PUBLIC_SUPABASE_URL
+  NEXT_PUBLIC_SUPABASE_ANON_KEY
+  SESSION_EXPIRY
+  S3_ENDPOINT
+  S3_REGION
+  S3_ACCESS_KEY_ID
+  S3_SECRET_ACCESS_KEY
+  S3_BUCKET
+  STRIPE_SECRET_KEY
+  POSTMARK_SERVER_TOKEN
+  POSTMARK_API_TOKEN
+  POSTMARK_MESSAGE_STREAM
+  EMAIL_DOMAIN
+  PUBLIC_APP_URL
+  CONVERSION_API_URL
+  CONVERSION_API_TIMEOUT
+  CONVERSION_POLLING_INTERVAL
+  TOOLPATH_API_KEY
+  RELEASE_VERSION
+)
+
+is_allowlisted() {
+  local key="$1"
+  local candidate
+  for candidate in "${ALLOWLIST[@]}"; do
+    if [[ "$candidate" == "$key" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+# Strip outer quotes; for unquoted values, drop trailing " # comment".
+normalize_value() {
+  local value="$1"
+  if [[ "$value" =~ ^\".*\"$ ]]; then
+    value="${value:1:${#value}-2}"
+  elif [[ "$value" =~ ^\'.*\'$ ]]; then
+    value="${value:1:${#value}-2}"
+  else
+    value="${value%% #*}"
+    # trim trailing whitespace
+    value="${value%"${value##*[![:space:]]}"}"
+  fi
+  printf '%s' "$value"
+}
+
+restore() {
+  if [[ ! -f "$BACKUP_FILE" ]]; then
+    echo "error: missing $BACKUP_FILE — nothing to restore" >&2
+    exit 1
+  fi
+
+  cp "$BACKUP_FILE" "$ENV_FILE"
+  rm -f "$BACKUP_FILE"
+  if [[ -d "$SECRETS_DIR" ]]; then
+    rm -rf "$SECRETS_DIR"
+  fi
+  echo "Restored .env from .env.bak and removed .secrets/"
+}
+
+convert() {
+  if [[ ! -f "$ENV_FILE" ]]; then
+    echo "error: missing $ENV_FILE" >&2
+    exit 1
+  fi
+  if [[ -f "$BACKUP_FILE" ]]; then
+    echo "error: $BACKUP_FILE already exists — run with --restore first" >&2
+    exit 1
+  fi
+  if [[ -d "$SECRETS_DIR" ]]; then
+    echo "error: $SECRETS_DIR already exists — run with --restore first (or remove it)" >&2
+    exit 1
+  fi
+
+  cp "$ENV_FILE" "$BACKUP_FILE"
+  mkdir -p "$SECRETS_DIR"
+
+  local tmp
+  tmp="$(mktemp)"
+  local converted=()
+  local skipped_empty=()
+
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    # Preserve blank lines and full-line comments
+    if [[ -z "$line" || "$line" =~ ^[[:space:]]*# ]]; then
+      printf '%s\n' "$line" >>"$tmp"
+      continue
+    fi
+
+    if [[ ! "$line" =~ ^([A-Za-z_][A-Za-z0-9_]*)=(.*)$ ]]; then
+      printf '%s\n' "$line" >>"$tmp"
+      continue
+    fi
+
+    local key="${BASH_REMATCH[1]}"
+    local raw_value="${BASH_REMATCH[2]}"
+
+    # Leave existing *_FILE entries and non-allowlist keys alone
+    if [[ "$key" == *_FILE ]] || ! is_allowlisted "$key"; then
+      printf '%s\n' "$line" >>"$tmp"
+      continue
+    fi
+
+    local value
+    value="$(normalize_value "$raw_value")"
+    if [[ -z "$value" ]]; then
+      skipped_empty+=("$key")
+      printf '%s\n' "$line" >>"$tmp"
+      continue
+    fi
+
+    # getEnv trims; a trailing newline on the secret file is fine
+    printf '%s\n' "$value" >"$SECRETS_DIR/$key"
+    printf '%s_FILE=.secrets/%s\n' "$key" "$key" >>"$tmp"
+    converted+=("$key")
+  done <"$ENV_FILE"
+
+  mv "$tmp" "$ENV_FILE"
+
+  echo "Backed up .env → .env.bak"
+  echo "Converted ${#converted[@]} key(s) to *_FILE under .secrets/:"
+  if [[ ${#converted[@]} -gt 0 ]]; then
+    printf '  - %s\n' "${converted[@]}"
+  fi
+  if [[ ${#skipped_empty[@]} -gt 0 ]]; then
+    echo "Skipped empty allowlist key(s):"
+    printf '  - %s\n' "${skipped_empty[@]}"
+  fi
+  echo
+  echo "Test with: npm run dev"
+  echo "Restore with: bash scripts/convert-env-to-files.sh --restore"
+}
+
+main() {
+  case "${1:-}" in
+    --restore)
+      restore
+      ;;
+    "" )
+      convert
+      ;;
+    -h|--help)
+      echo "Usage: bash scripts/convert-env-to-files.sh [--restore]"
+      ;;
+    *)
+      echo "error: unknown argument: $1" >&2
+      echo "Usage: bash scripts/convert-env-to-files.sh [--restore]" >&2
+      exit 1
+      ;;
+  esac
+}
+
+main "$@"

--- a/scripts/convert-env-to-files.sh
+++ b/scripts/convert-env-to-files.sh
@@ -54,12 +54,15 @@ is_allowlisted() {
 }
 
 # Strip outer quotes; for unquoted values, drop trailing " # comment".
+# Also handles quoted values followed by inline comments: FOO="bar" # comment
 normalize_value() {
   local value="$1"
-  if [[ "$value" =~ ^\".*\"$ ]]; then
-    value="${value:1:${#value}-2}"
-  elif [[ "$value" =~ ^\'.*\'$ ]]; then
-    value="${value:1:${#value}-2}"
+  local dquote_re='^"(.*)"[[:space:]]*(#.*)?$'
+  local squote_re="^'(.*)'[[:space:]]*(#.*)?$"
+  if [[ "$value" =~ $dquote_re ]]; then
+    value="${BASH_REMATCH[1]}"
+  elif [[ "$value" =~ $squote_re ]]; then
+    value="${BASH_REMATCH[1]}"
   else
     value="${value%% #*}"
     # trim trailing whitespace
@@ -101,10 +104,13 @@ convert() {
 
   local tmp
   tmp="$(mktemp)"
+  trap 'rm -f "$tmp"' EXIT
   local converted=()
   local skipped_empty=()
 
   while IFS= read -r line || [[ -n "$line" ]]; do
+    # Strip trailing carriage return for CRLF compatibility
+    line="${line%$'\r'}"
     # Preserve blank lines and full-line comments
     if [[ -z "$line" || "$line" =~ ^[[:space:]]*# ]]; then
       printf '%s\n' "$line" >>"$tmp"
@@ -140,6 +146,7 @@ convert() {
   done <"$ENV_FILE"
 
   mv "$tmp" "$ENV_FILE"
+  trap - EXIT
 
   echo "Backed up .env → .env.bak"
   echo "Converted ${#converted[@]} key(s) to *_FILE under .secrets/:"

--- a/scripts/init-feature-flags.ts
+++ b/scripts/init-feature-flags.ts
@@ -1,0 +1,15 @@
+import { initializeFeatureFlags } from "../app/lib/featureFlags";
+
+async function init() {
+  try {
+    console.log("Initializing feature flags...");
+    await initializeFeatureFlags();
+    console.log("Feature flags initialized successfully!");
+  } catch (error) {
+    console.error("Failed to initialize feature flags:", error);
+    process.exit(1);
+  }
+  process.exit(0);
+}
+
+init();

--- a/scripts/patch-drizzle-kit-progress.mjs
+++ b/scripts/patch-drizzle-kit-progress.mjs
@@ -1,0 +1,81 @@
+/**
+ * drizzle-kit bundles TaskTerminal.reject(err) but ProgressView / MigrateProgress
+ * render("rejected") like "pending" and ignore `err`, then process.exit(1) — so failures look "silent".
+ * Re-apply after every `npm install` (see package.json postinstall).
+ */
+import { readFileSync, writeFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const binPath = join(root, "node_modules", "drizzle-kit", "bin.cjs");
+
+let bin;
+try {
+  bin = readFileSync(binPath, "utf8");
+} catch {
+  process.exit(0);
+}
+
+const migrateFrom = `      render(status) {
+        if (status === "pending" || status === "rejected") {
+          const spin = this.spinner.value();
+          return \`[\${spin}] applying migrations...\`;
+        }
+        return \`[\${source_default.green("\\u2713")}] migrations applied successfully!\`;
+      }`;
+
+const migrateTo = `      render(status, err2) {
+        if (status === "rejected" && err2) {
+          const msg =
+            err2 instanceof Error ? err2.message || String(err2) : String(err2);
+          return \`[\${source_default.red("x")}] \${msg}\`;
+        }
+        if (status === "pending") {
+          const spin = this.spinner.value();
+          return \`[\${spin}] applying migrations...\`;
+        }
+        return \`[\${source_default.green("\\u2713")}] migrations applied successfully!\`;
+      }`;
+
+const pushFrom = `      render(status) {
+        if (status === "pending" || status === "rejected") {
+          const spin = this.spinner.value();
+          return \`[\${spin}] \${this.progressText}
+\`;
+        }
+        return \`[\${source_default.green("\\u2713")}] \${this.successText}
+\`;
+      }`;
+
+const pushTo = `      render(status, err2) {
+        if (status === "rejected" && err2) {
+          const msg =
+            err2 instanceof Error ? err2.message || String(err2) : String(err2);
+          return \`[\${source_default.red("x")}] \${msg}
+\`;
+        }
+        if (status === "pending") {
+          const spin = this.spinner.value();
+          return \`[\${spin}] \${this.progressText}
+\`;
+        }
+        return \`[\${source_default.green("\\u2713")}] \${this.successText}
+\`;
+      }`;
+
+let next = bin;
+let changed = false;
+
+if (next.includes(migrateFrom)) {
+  next = next.replace(migrateFrom, migrateTo);
+  changed = true;
+}
+if (next.includes(pushFrom)) {
+  next = next.replace(pushFrom, pushTo);
+  changed = true;
+}
+
+if (changed) {
+  writeFileSync(binPath, next, "utf8");
+}

--- a/scripts/patch-drizzle-kit-progress.mjs
+++ b/scripts/patch-drizzle-kit-progress.mjs
@@ -5,6 +5,7 @@
  */
 import { readFileSync, writeFileSync } from "node:fs";
 import { join, dirname } from "node:path";
+import process from "node:process";
 import { fileURLToPath } from "node:url";
 
 const root = join(dirname(fileURLToPath(import.meta.url)), "..");
@@ -13,8 +14,10 @@ const binPath = join(root, "node_modules", "drizzle-kit", "bin.cjs");
 let bin;
 try {
   bin = readFileSync(binPath, "utf8");
-} catch {
-  process.exit(0);
+} catch (error) {
+  const detail = error instanceof Error ? error.message : String(error);
+  console.error(`Failed to read drizzle-kit bin at ${binPath}: ${detail}`);
+  process.exit(1);
 }
 
 const migrateFrom = `      render(status) {
@@ -70,10 +73,21 @@ let changed = false;
 if (next.includes(migrateFrom)) {
   next = next.replace(migrateFrom, migrateTo);
   changed = true;
+} else if (!next.includes(migrateTo)) {
+  console.error(
+    "Could not find migrate progress render block in drizzle-kit bin.cjs (neither original nor already patched).",
+  );
+  process.exit(1);
 }
+
 if (next.includes(pushFrom)) {
   next = next.replace(pushFrom, pushTo);
   changed = true;
+} else if (!next.includes(pushTo)) {
+  console.error(
+    "Could not find push progress render block in drizzle-kit bin.cjs (neither original nor already patched).",
+  );
+  process.exit(1);
 }
 
 if (changed) {

--- a/scripts/seed-email-config.ts
+++ b/scripts/seed-email-config.ts
@@ -1,0 +1,126 @@
+import { db } from "../app/lib/db";
+import {
+  emailSettings,
+  emailIdentities,
+  emailTemplates,
+} from "../app/lib/db/schema";
+import { eq } from "drizzle-orm";
+import { EMAIL_CONTEXT } from "../app/lib/email/email-context-registry";
+
+async function main() {
+  console.log("Seeding email configuration...");
+
+  // 1. Seed email_settings
+  const defaultSettings = [
+    { key: "outbound_delay_minutes", value: "0" },
+    { key: "recipient_override", value: "" },
+    { key: "default_signature", value: "" },
+    { key: "default_footer", value: "" },
+  ];
+
+  for (const setting of defaultSettings) {
+    const existing = await db
+      .select()
+      .from(emailSettings)
+      .where(eq(emailSettings.key, setting.key))
+      .limit(1);
+
+    if (existing.length === 0) {
+      await db.insert(emailSettings).values({
+        key: setting.key,
+        value: setting.value,
+        updatedBy: "system",
+      });
+      console.log(`Inserted setting: ${setting.key}`);
+    } else {
+      console.log(`Setting already exists: ${setting.key}`);
+    }
+  }
+
+  // 2. Seed email_identities
+  const defaultIdentityEmail = "quotes@subtract.com"; // Placeholder, should be updated by admin
+  const existingIdentity = await db
+    .select()
+    .from(emailIdentities)
+    .where(eq(emailIdentities.isDefault, true))
+    .limit(1);
+
+  let identityId: number;
+
+  if (existingIdentity.length === 0) {
+    const [newIdentity] = await db
+      .insert(emailIdentities)
+      .values({
+        fromEmail: defaultIdentityEmail,
+        fromDisplayName: "Subtract Manufacturing",
+        isDefault: true,
+        updatedBy: "system",
+      })
+      .returning();
+    identityId = newIdentity.id;
+    console.log(`Inserted default identity: ${defaultIdentityEmail}`);
+  } else {
+    identityId = existingIdentity[0].id;
+    console.log(`Default identity already exists: ${existingIdentity[0].fromEmail}`);
+  }
+
+  // 3. Seed email_templates (quote send — Styled quote layout)
+  const existingTemplate = await db
+    .select()
+    .from(emailTemplates)
+    .where(eq(emailTemplates.slug, "quote-send"))
+    .limit(1);
+
+  let templateId: number;
+
+  if (existingTemplate.length === 0) {
+    const [inserted] = await db
+      .insert(emailTemplates)
+      .values({
+        slug: "quote-send",
+        name: "Quote Send",
+        layoutSlug: "styled-quote",
+        contextKey: EMAIL_CONTEXT.QUOTE_SEND,
+        emailIdentityId: identityId,
+        requiredAttachmentDocumentKinds: ["quote"],
+        subjectTemplate: "Your Quote {{quoteNumber}} from Subtract Manufacturing",
+        bodyCopy: {
+          intro:
+            "Hi {{customerName}},\n\nPlease find your quote **{{quoteNumber}}** attached.\n\n**Total:** {{total}}",
+          cta: {
+            buttonLabel: "Pay Now",
+            link: "{{paymentLinkUrl}}",
+          },
+          wrapUp:
+            "Best regards,\n\nSubtract Manufacturing\n\n{{default_signature}}",
+          footerNotice: "{{default_footer}}",
+        },
+        updatedBy: "system",
+      })
+      .returning();
+    templateId = inserted.id;
+    console.log(`Inserted template: quote-send`);
+  } else {
+    templateId = existingTemplate[0].id;
+    console.log(`Template already exists: quote-send`);
+    await db
+      .update(emailTemplates)
+      .set({
+        contextKey: EMAIL_CONTEXT.QUOTE_SEND,
+        updatedAt: new Date(),
+        updatedBy: "system",
+      })
+      .where(eq(emailTemplates.id, templateId));
+  }
+  console.log(
+    `Assigned context ${EMAIL_CONTEXT.QUOTE_SEND} to template id ${templateId}`
+  );
+
+  console.log("Seeding complete.");
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error("Error seeding email configuration:", err);
+  process.exit(1);
+});

--- a/scripts/seed-email-config.ts
+++ b/scripts/seed-email-config.ts
@@ -37,9 +37,9 @@ async function main() {
     }
   }
 
-  // 2. Seed email_identities
+  // 2. Seed email_identities (placeholder — archived until an admin configures a real sender)
   const defaultIdentityEmail = "quotes@subtract.com"; // Placeholder, should be updated by admin
-  const existingIdentity = await db
+  const existingDefault = await db
     .select()
     .from(emailIdentities)
     .where(eq(emailIdentities.isDefault, true))
@@ -47,21 +47,35 @@ async function main() {
 
   let identityId: number;
 
-  if (existingIdentity.length === 0) {
-    const [newIdentity] = await db
-      .insert(emailIdentities)
-      .values({
-        fromEmail: defaultIdentityEmail,
-        fromDisplayName: "Subtract Manufacturing",
-        isDefault: true,
-        updatedBy: "system",
-      })
-      .returning();
-    identityId = newIdentity.id;
-    console.log(`Inserted default identity: ${defaultIdentityEmail}`);
+  if (existingDefault.length > 0) {
+    identityId = existingDefault[0].id;
+    console.log(`Default identity already exists: ${existingDefault[0].fromEmail}`);
   } else {
-    identityId = existingIdentity[0].id;
-    console.log(`Default identity already exists: ${existingIdentity[0].fromEmail}`);
+    const existingPlaceholder = await db
+      .select()
+      .from(emailIdentities)
+      .where(eq(emailIdentities.fromEmail, defaultIdentityEmail))
+      .limit(1);
+
+    if (existingPlaceholder.length > 0) {
+      identityId = existingPlaceholder[0].id;
+      console.log(`Placeholder identity already exists: ${defaultIdentityEmail}`);
+    } else {
+      const [newIdentity] = await db
+        .insert(emailIdentities)
+        .values({
+          fromEmail: defaultIdentityEmail,
+          fromDisplayName: "Subtract Manufacturing",
+          isDefault: false,
+          isArchived: true,
+          updatedBy: "system",
+        })
+        .returning();
+      identityId = newIdentity.id;
+      console.log(
+        `Inserted archived placeholder identity: ${defaultIdentityEmail} (not default — configure in admin)`,
+      );
+    }
   }
 
   // 3. Seed email_templates (quote send — Styled quote layout)

--- a/scripts/sync-auth-users.ts
+++ b/scripts/sync-auth-users.ts
@@ -1,0 +1,98 @@
+import { createClient } from "@supabase/supabase-js";
+import { db } from "../app/lib/db";
+import { users, type NewUser } from "../app/lib/db/schema";
+import { eq } from "drizzle-orm";
+import dotenv from "dotenv";
+
+// Load environment variables
+dotenv.config();
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!supabaseUrl || !supabaseServiceKey) {
+  console.error("Missing required environment variables:");
+  console.error("- NEXT_PUBLIC_SUPABASE_URL");
+  console.error("- SUPABASE_SERVICE_ROLE_KEY (admin/service role key needed)");
+  process.exit(1);
+}
+
+// Create admin client with service role key to access auth.users
+const supabase = createClient(supabaseUrl, supabaseServiceKey, {
+  auth: {
+    autoRefreshToken: false,
+    persistSession: false,
+  },
+});
+
+async function syncAuthUsers() {
+  try {
+    console.log("Starting auth user sync...");
+    
+    // Fetch all users from Supabase auth
+    const { data: authUsers, error } = await supabase.auth.admin.listUsers();
+    
+    if (error) {
+      console.error("Error fetching auth users:", error);
+      return;
+    }
+    
+    if (!authUsers || authUsers.users.length === 0) {
+      console.log("No auth users found");
+      return;
+    }
+    
+    console.log(`Found ${authUsers.users.length} auth users`);
+    
+    for (const authUser of authUsers.users) {
+      try {
+        // Check if user already exists in public.users
+        const existingUser = await db
+          .select()
+          .from(users)
+          .where(eq(users.id, authUser.id))
+          .limit(1);
+        
+        if (existingUser.length > 0) {
+          // Update existing user
+          console.log(`Updating user: ${authUser.email}`);
+          await db
+            .update(users)
+            .set({
+              email: authUser.email || '',
+              name: authUser.user_metadata?.name || authUser.user_metadata?.full_name || null,
+              updatedAt: new Date(),
+            })
+            .where(eq(users.id, authUser.id));
+        } else {
+          // Create new user
+          console.log(`Creating user: ${authUser.email}`);
+          const newUser: NewUser = {
+            id: authUser.id,
+            email: authUser.email || '',
+            name: authUser.user_metadata?.name || authUser.user_metadata?.full_name || null,
+            role: "User", // Default role
+          };
+          
+          await db.insert(users).values(newUser);
+        }
+      } catch (userError) {
+        console.error(`Error syncing user ${authUser.email}:`, userError);
+      }
+    }
+    
+    console.log("Auth user sync completed successfully!");
+    
+    // Show summary
+    const totalUsers = await db.select().from(users);
+    console.log(`Total users in database: ${totalUsers.length}`);
+    
+  } catch (error) {
+    console.error("Sync failed:", error);
+  } finally {
+    process.exit(0);
+  }
+}
+
+// Run the sync
+syncAuthUsers();

--- a/scripts/sync-auth-users.ts
+++ b/scripts/sync-auth-users.ts
@@ -1,21 +1,13 @@
-import { createClient } from "@supabase/supabase-js";
+import "dotenv/config";
+import { createClient, type User } from "@supabase/supabase-js";
 import { db } from "../app/lib/db";
 import { users, type NewUser } from "../app/lib/db/schema";
 import { eq } from "drizzle-orm";
-import dotenv from "dotenv";
+import { getEnv, requireEnv } from "../app/lib/env.server";
 
-// Load environment variables
-dotenv.config();
-
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
-const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
-
-if (!supabaseUrl || !supabaseServiceKey) {
-  console.error("Missing required environment variables:");
-  console.error("- NEXT_PUBLIC_SUPABASE_URL");
-  console.error("- SUPABASE_SERVICE_ROLE_KEY (admin/service role key needed)");
-  process.exit(1);
-}
+const supabaseUrl =
+  getEnv("SUPABASE_URL") || requireEnv("NEXT_PUBLIC_SUPABASE_URL");
+const supabaseServiceKey = requireEnv("SUPABASE_SERVICE_ROLE_KEY");
 
 // Create admin client with service role key to access auth.users
 const supabase = createClient(supabaseUrl, supabaseServiceKey, {
@@ -25,74 +17,121 @@ const supabase = createClient(supabaseUrl, supabaseServiceKey, {
   },
 });
 
+function userLabel(authUser: { id: string }): string {
+  return authUser.id;
+}
+
+async function listAllAuthUsers(): Promise<User[]> {
+  const allUsers: User[] = [];
+  const perPage = 100;
+  let page = 1;
+
+  for (;;) {
+    const { data, error } = await supabase.auth.admin.listUsers({
+      page,
+      perPage,
+    });
+
+    if (error) {
+      throw error;
+    }
+
+    const batch = data.users;
+    allUsers.push(...batch);
+
+    if (batch.length < perPage) {
+      break;
+    }
+    page += 1;
+  }
+
+  return allUsers;
+}
+
 async function syncAuthUsers() {
+  let hadFailure = false;
+
   try {
     console.log("Starting auth user sync...");
-    
-    // Fetch all users from Supabase auth
-    const { data: authUsers, error } = await supabase.auth.admin.listUsers();
-    
-    if (error) {
-      console.error("Error fetching auth users:", error);
-      return;
-    }
-    
-    if (!authUsers || authUsers.users.length === 0) {
+
+    const authUsers = await listAllAuthUsers();
+
+    if (authUsers.length === 0) {
       console.log("No auth users found");
       return;
     }
-    
-    console.log(`Found ${authUsers.users.length} auth users`);
-    
-    for (const authUser of authUsers.users) {
+
+    console.log(`Found ${authUsers.length} auth users`);
+
+    for (const authUser of authUsers) {
       try {
-        // Check if user already exists in public.users
         const existingUser = await db
           .select()
           .from(users)
           .where(eq(users.id, authUser.id))
           .limit(1);
-        
+
+        const name =
+          authUser.user_metadata?.name ||
+          authUser.user_metadata?.full_name ||
+          null;
+
         if (existingUser.length > 0) {
-          // Update existing user
-          console.log(`Updating user: ${authUser.email}`);
-          await db
-            .update(users)
-            .set({
-              email: authUser.email || '',
-              name: authUser.user_metadata?.name || authUser.user_metadata?.full_name || null,
-              updatedAt: new Date(),
-            })
-            .where(eq(users.id, authUser.id));
+          console.log(`Updating user: ${userLabel(authUser)}`);
+          const update: {
+            name: string | null;
+            updatedAt: Date;
+            email?: string;
+          } = {
+            name,
+            updatedAt: new Date(),
+          };
+          // Preserve stored email when Auth user has no email
+          if (authUser.email) {
+            update.email = authUser.email;
+          }
+          await db.update(users).set(update).where(eq(users.id, authUser.id));
         } else {
-          // Create new user
-          console.log(`Creating user: ${authUser.email}`);
+          if (!authUser.email) {
+            console.error(
+              `Skipping create for user ${userLabel(authUser)}: missing email`,
+            );
+            hadFailure = true;
+            continue;
+          }
+          console.log(`Creating user: ${userLabel(authUser)}`);
           const newUser: NewUser = {
             id: authUser.id,
-            email: authUser.email || '',
-            name: authUser.user_metadata?.name || authUser.user_metadata?.full_name || null,
-            role: "User", // Default role
+            email: authUser.email,
+            name,
+            role: "User",
           };
-          
+
           await db.insert(users).values(newUser);
         }
       } catch (userError) {
-        console.error(`Error syncing user ${authUser.email}:`, userError);
+        hadFailure = true;
+        console.error(
+          `Error syncing user ${userLabel(authUser)}:`,
+          userError,
+        );
       }
     }
-    
-    console.log("Auth user sync completed successfully!");
-    
-    // Show summary
+
+    if (hadFailure) {
+      console.error("Auth user sync completed with errors.");
+    } else {
+      console.log("Auth user sync completed successfully!");
+    }
+
     const totalUsers = await db.select().from(users);
     console.log(`Total users in database: ${totalUsers.length}`);
-    
   } catch (error) {
+    hadFailure = true;
     console.error("Sync failed:", error);
   } finally {
-    process.exit(0);
+    process.exit(hadFailure ? 1 : 0);
   }
 }
 
-// Run the sync
 syncAuthUsers();

--- a/scripts/test-env.ts
+++ b/scripts/test-env.ts
@@ -11,7 +11,7 @@ if (process.env.DATABASE_URL) {
   console.log('DATABASE_URL points to:', isLocalhost ? 'localhost (incorrect for Supabase)' : 'remote database (correct)');
   
   // Show just the host part (safe to display)
-  const match = process.env.DATABASE_URL.match(/postgresql:\/\/[^@]+@([^:\/]+)/);
+  const match = process.env.DATABASE_URL.match(/postgresql:\/\/[^@]+@([^:/]+)/);
   if (match) {
     console.log('Database host:', match[1]);
   }

--- a/scripts/test-simple-connection.ts
+++ b/scripts/test-simple-connection.ts
@@ -6,7 +6,7 @@ async function testConnection() {
   console.log('Testing connection to Supabase...\n');
   
   // Extract host for logging
-  const hostMatch = url.match(/@([^:\/]+)/);
+  const hostMatch = url.match(/@([^:/]+)/);
   if (hostMatch) {
     console.log('Connecting to:', hostMatch[1]);
   }
@@ -32,18 +32,23 @@ async function testConnection() {
     // End connection
     await sql.end();
     
-  } catch (error: any) {
+  } catch (error: unknown) {
     console.error('\n❌ Connection failed!');
-    console.error('Error:', error.message);
+    const message = error instanceof Error ? error.message : String(error);
+    const code =
+      error && typeof error === 'object' && 'code' in error
+        ? String((error as { code: unknown }).code)
+        : undefined;
+    console.error('Error:', message);
     
-    if (error.code === 'ENETUNREACH') {
+    if (code === 'ENETUNREACH') {
       console.log('\n💡 Network unreachable. Possible solutions:');
       console.log('1. Check your internet connection');
       console.log('2. Try using a VPN if you\'re behind a restrictive firewall');
       console.log('3. Check if your Supabase project is paused (free tier)');
-    } else if (error.code === 'ENOTFOUND') {
+    } else if (code === 'ENOTFOUND') {
       console.log('\n💡 Host not found. Check your DATABASE_URL');
-    } else if (error.message.includes('password')) {
+    } else if (message.includes('password')) {
       console.log('\n💡 Authentication failed. Check your database password');
     }
   }

--- a/scripts/test-supabase-client.ts
+++ b/scripts/test-supabase-client.ts
@@ -30,7 +30,7 @@ async function testSupabaseConnection() {
     
     // Test database via Supabase client
     console.log('\nTesting database query via Supabase client...');
-    const { data, error } = await supabase
+    const { error } = await supabase
       .from('users')
       .select('count')
       .limit(1);
@@ -44,8 +44,9 @@ async function testSupabaseConnection() {
       console.log('✅ Database accessible via Supabase client');
     }
     
-  } catch (error: any) {
-    console.error('\n❌ Unexpected error:', error.message);
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error('\n❌ Unexpected error:', message);
   }
   
   console.log('\n📌 Next steps:');


### PR DESCRIPTION
## What changed?

Add *_FILE based environment loading that takes precedent over tagged environment variables. Uses a centralized getEnv helper

## Type

- [ ] Bug fix
- [x] New feature
- [ ] Refactor/cleanup
- [ ] Other

## Related issue

Closes #

## Checklist

- [x] Tested locally
- [x] No lint/type errors
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Docker Swarm/Compose “file-based secrets” support via `*_FILE` environment variables.
  * Implemented a dedicated server-side Supabase client with session invalidation based on last activity.
  * Centralized environment configuration across database, storage, email, payments, and toolpath.

* **Bug Fixes**
  * Improved handling of missing/empty/unreadable secret files, including correct precedence and trimming.
  * Made environment-driven configuration consistent everywhere, including queued DB and connection settings.

* **Documentation**
  * Updated example environment files and Docker docs with `*_FILE` guidance.

* **Tests**
  * Added/adjusted environment and integration tests to validate cached and secret-based behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->